### PR TITLE
Fix spelling for Samen assignee

### DIFF
--- a/custom_components/chores_manager/www/chores-dashboard/js/utils.js
+++ b/custom_components/chores_manager/www/chores-dashboard/js/utils.js
@@ -326,7 +326,7 @@ window.choreUtils.getBackgroundColor = function(assignedTo, assigneesList = []) 
     switch (assignedTo) {
         case 'Martijn': return 'bg-yellow-100 border-yellow-400';
         case 'Laura': return 'bg-red-100 border-red-400';
-        case 'Sammen': return 'bg-blue-100 border-blue-400';
+        case 'Samen': return 'bg-blue-100 border-blue-400';
         case 'Wie kan': return 'bg-green-100 border-green-400';
         default: return 'bg-gray-100 border-gray-400';
     }


### PR DESCRIPTION
## Summary
- fix spelling for "Samen" in the dashboard background color switch

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688373debf408333a766473a0acac69b