### PR TITLE
Fix API initialization race

### DIFF
--- a/custom_components/chores_manager/www/chores-dashboard/js/app-handlers.js
+++ b/custom_components/chores_manager/www/chores-dashboard/js/app-handlers.js
@@ -33,13 +33,13 @@ window.ChoresApp = window.ChoresApp || {};
                 try {
                     if (window.ChoresAPI && window.ChoresAPI.initialize) {
                         console.log('Initializing Chores Dashboard App');
-                        
+
                         const apiMethods = Object.keys(window.ChoresAPI);
                         console.log('ChoresAPI available methods:', apiMethods);
-                        
+
                         await window.ChoresAPI.initialize();
                         console.log('API initialized successfully');
-                        
+
                         core.setApi(window.ChoresAPI);
                     } else {
                         throw new Error('ChoresAPI not available');
@@ -50,8 +50,19 @@ window.ChoresApp = window.ChoresApp || {};
                     core.setLoading(false);
                 }
             };
-            
-            initializeAPI();
+
+            // Wait for the API ready event to avoid race conditions
+            const onApiReady = () => initializeAPI();
+            window.addEventListener('chores-api-ready', onApiReady);
+
+            // If the API is already available, initialize immediately
+            if (window.ChoresAPI && window.ChoresAPI.initialize) {
+                initializeAPI();
+            }
+
+            return () => {
+                window.removeEventListener('chores-api-ready', onApiReady);
+            };
         }, [handleError, core]);
         
         // Load data


### PR DESCRIPTION
## Summary
- wait for Chores API ready event before initialising handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e3e409d48333ba5e6a5eff9780d0