### PR TITLE
Fix repeated API initialization

### DIFF
--- a/custom_components/chores_manager/www/chores-dashboard/js/app-handlers.js
+++ b/custom_components/chores_manager/www/chores-dashboard/js/app-handlers.js
@@ -27,7 +27,7 @@ window.ChoresApp = window.ChoresApp || {};
             }
         }, [core, status]);
         
-        // Initialize API
+        // Initialize API only once when the component mounts
         useEffect(() => {
             const initializeAPI = async () => {
                 try {
@@ -63,7 +63,8 @@ window.ChoresApp = window.ChoresApp || {};
             return () => {
                 window.removeEventListener('chores-api-ready', onApiReady);
             };
-        }, [handleError, core]);
+        // Empty dependency array prevents re-registration on each render
+        }, []);
         
         // Load data
         const loadData = useCallback(async () => {


### PR DESCRIPTION
## Summary
- prevent re-registering the API init effect on every render

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68862c4831508333a1d7cdd61ae1c9d9