### PR TITLE
Fix window reference in dashboard API modules

### DIFF
--- a/custom_components/chores_manager/www/chores-dashboard/js/api/base.js
+++ b/custom_components/chores_manager/www/chores-dashboard/js/api/base.js
@@ -509,4 +509,4 @@
     window.ChoresAPI.ENDPOINTS = ENDPOINTS;
     
     console.log('BaseAPI loaded successfully with exponential backoff and retry logic');
-})();
+})(window);

--- a/custom_components/chores_manager/www/chores-dashboard/js/api/chores.js
+++ b/custom_components/chores_manager/www/chores-dashboard/js/api/chores.js
@@ -347,4 +347,4 @@
     window.ChoresAPI.ChoresAPI = ChoresAPI;
     
     console.log('ChoresAPI.ChoresAPI loaded successfully');
-})();
+})(window);


### PR DESCRIPTION
## Summary
- pass the global `window` object into `base.js` and `chores.js` IIFEs so the Chores Dashboard loads correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2f776c74483339969b35228bb3b14