### PR TITLE
fix: call updated init function

### DIFF
--- a/custom_components/chores_manager/www/chores-dashboard/index.html
+++ b/custom_components/chores_manager/www/chores-dashboard/index.html
@@ -256,6 +256,7 @@
                 if (!window.choreUtils) missing.push('choreUtils');
                 if (!window.choreComponents) missing.push('choreComponents');
                 if (!window.ChoresApp) missing.push('ChoresApp');
+                if (window.ChoresApp && typeof window.ChoresApp.initApp !== 'function') missing.push('ChoresApp.initApp');
                 if (!window.ChoresAPI) missing.push('ChoresAPI');
                 if (window.ChoresAPI && !window.ChoresAPI.ENDPOINTS) missing.push('ChoresAPI.ENDPOINTS');
 
@@ -263,10 +264,10 @@
                     // All dependencies loaded, initialize the app
                     console.log('All dependencies loaded, initializing app...');
                     try {
-                        if (window.ChoresApp && typeof window.ChoresApp.init === 'function') {
-                            window.ChoresApp.init();
+                        if (window.ChoresApp && typeof window.ChoresApp.initApp === 'function') {
+                            window.ChoresApp.initApp();
                         } else {
-                            throw new Error('ChoresApp.init not available');
+                            throw new Error('ChoresApp.initApp not available');
                         }
                     } catch (error) {
                         console.error('Failed to initialize ChoresApp:', error);

--- a/custom_components/chores_manager/www/chores-dashboard/js/app-init.js
+++ b/custom_components/chores_manager/www/chores-dashboard/js/app-init.js
@@ -122,6 +122,12 @@ window.ChoresApp = window.ChoresApp || {};
             `;
         }
     };
-    
+
+    // Maintain backward compatibility with older initialization name
+    window.ChoresApp.init = function() {
+        console.warn('ChoresApp.init is deprecated, use ChoresApp.initApp instead.');
+        return window.ChoresApp.initApp.apply(window.ChoresApp, arguments);
+    };
+
     console.log('App initialization module loaded');
 })();


### PR DESCRIPTION
## Summary
- call `ChoresApp.initApp()` during dashboard boot instead of removed `init`
- ensure dependency check waits for `ChoresApp.initApp`
- alias deprecated `ChoresApp.init` to `initApp` for backward compatibility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2f9df45d0833393333960109f9abf