### PR TITLE
docs: sequencing, resources en panelroute corrigeren

### DIFF
--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -308,8 +308,10 @@ huidige muur waarin 8 van de 8 taken rood zijn.
 - `anyone` — niemand specifiek; iedereen kan afvinken.
 
 Op de kaart staat bij `rotating` zichtbaar wie aan de beurt is. Dat is nu de
-onduidelijkste plek in het formulier: `alternate_with` is bij vijf taken gevuld
-terwijl `use_alternating` op 0 staat, dus die instelling doet niets.
+onduidelijkste plek in het formulier: `alternate_with` is bij vijf taken
+gevuld, maar bij vier daarvan staat `use_alternating` op 0, dus daar doet de
+instelling niets. Alleen de AH-boodschappenlijst roteert echt (Martijn ↔
+Laura); zie `docs/legacy-state.yaml` en `tests/test_legacy_tasks.py`.
 
 ### 4.5 Deeltaken
 

--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -493,6 +493,15 @@ daadwerkelijk.
 
 - `TECHNICAL_DESCRIPTION.md` — dubbel.
 
+**Lovelace-resources — opgeruimd op 28-07-2026.** In HA stonden twee
+resource-registraties (buiten de repo) die naar deze map wezen:
+`/local/chores-dashboard/js/components.js` en
+`/local/chores-dashboard/js/utils.js`, beide als JavaScript-module. Daardoor
+werden die twee bestanden ook in het **buitenste** HA-document geladen, op elk
+dashboard. Beide registraties zijn verwijderd; `js/components.js` en
+`js/utils.js` kunnen dus zonder 404-risico geschrapt worden. Zie
+`docs/legacy-notes.md` voor de correctie op de oorspronkelijke classificatie.
+
 ### `database.py` verhuist, het verdwijnt niet
 
 `database.py` (384 regels) stond eerder op deze lijst. Dat was onjuist.
@@ -602,13 +611,35 @@ wordt nergens geladen. Het wit verdwijnt pas in fase 3, met de HA-CSS-variabelen
 **Klaar wanneer:** één initialisatie in de console, en een tweede pageload haalt
 bestanden uit de cache.
 
-### Fase 2 — Backend (2–3 dagen)
+### Fase 2 — Backend (2–3 dagen, branch `refactor/v2`)
 
-- Nieuw schema (§3), verse database.
-- `scheduling/` met de vijf types en de doorrollogica (§4.1, §4.2).
+**Branchstrategie.** Fase 2 en 3 leven samen op één branch, `refactor/v2`, en
+gaan pas sámen naar main. Reden: fase 2 vervangt het schema en slankt de sensor
+af, en daarmee breekt de huidige frontend — die leest `overdue_tasks` uit de
+sensorattributen — vóórdat fase 3 hem vervangt. Main houdt dus de werkende oude
+app tot het geheel af is.
+
+**Wat er in fase 2 wél en niet verdwijnt.** Alleen de twee onbereikbare
+Python-bestanden gaan weg: `services.py` en `utils.py`. Alles onder `www/`
+blijft staan tot fase 3; de overige verwijderingen uit §7 schuiven mee naar
+fase 3.
+
+#### Fase 2a — Schema en planningslogica (zelfstandig verifieerbaar)
+
+- Nieuw schema (§3) in `db/schema.py`, verbindingslaag in `db/connection.py`.
+  De bestaande DDL in `db/base.py`, `theme_service.py` en `db/migrations.py`
+  blijft in 2a onaangeroerd; die wordt in 2b ontmanteld.
+- `scheduling/` met de vijf types (§4.1), de doorrollogica (§4.2), urgentie
+  (§4.3) en rotatie (§4.4).
 - **Unit tests, alleen hier.** De planningslogica is de enige plek waar tests
   echt lonen: `next_due` bij elk type, doorrollen over maand- en jaargrenzen,
   schrikkeljaar, achterstandsberekening per prioriteit, rotatie-index.
+- Sluit nog nergens op HA aan.
+
+**Klaar wanneer:** de tests slagen met pytest, zonder draaiende Home Assistant.
+
+#### Fase 2b — Aansluiten op HA
+
 - WS-commando's (§2.3).
 - Afgeslankte sensor + sensor per persoon (§2.4).
 - `scheduler.py` met de nachtelijke rol.
@@ -620,16 +651,24 @@ bestanden uit de cache.
   `services/chore_services.py:17`, `services/chore_services.py:249`,
   `services/user_services.py:9`, `services/notification_services.py:9` en
   `utils/notifications.py:13`. Pas als die alle acht om zijn, mag het bestand weg.
-- DDL samenbrengen in `db/schema.py`. Die staat nu op drie plekken:
-  `db/base.py:77-176`, `theme_service.py:18` en `db/migrations.py:117`.
-- Overige oude bestanden verwijderen (§7).
+- Oude DDL ontmantelen; alle DDL staat daarna alleen nog in `db/schema.py`. De
+  oude staat nu op drie plekken: `db/base.py:77-176`, `theme_service.py:18` en
+  `db/migrations.py:117`.
+- `services.py` en `utils.py` (onbereikbaar, §7) verwijderen.
 
 **Klaar wanneer:** je kunt via Developer Tools → Services een taak aanmaken,
 afvinken en zien dat `next_due` correct doorrolt; de tests slagen; de sensor toont
 kloppende samenvattingen.
 
-### Fase 3 — Frontend (3–5 dagen)
+### Fase 3 — Frontend (3–5 dagen, branch `refactor/v2`)
 
+- Doorwerken op `refactor/v2`; aan het einde van deze fase gaat de branch als
+  geheel naar main.
+- **De oude ingang blijft tot het einde staan.** De panelroute `/chores` is al
+  kapot — `chores-dashboard.js` gooit een TypeError in zijn onload-handler, zie
+  `docs/legacy-notes.md` — dus het Lovelace-dashboard `/dashboard-chores/taken`
+  is de enige werkende ingang. Die mag pas verdwijnen als het nieuwe panel
+  aantoonbaar draait.
 - `panel.py` omzetten naar `module_url`, `embed_iframe: false`.
 - `chores-panel.js` met `hass`-setter en WS-abonnement.
 - `core/` (api, store, html, format).
@@ -637,6 +676,8 @@ kloppende samenvattingen.
 - Optimistisch afvinken met terugdraaien bij fout, plus "Ongedaan maken" in de
   bevestiging.
 - `styles.css` op HA-variabelen.
+- De uitgestelde verwijderingen uit §7 (alles onder `www/`, `theme_service.py`,
+  de `theme_settings`-tabel) alsnog doorvoeren zodra het nieuwe panel draait.
 
 **Klaar wanneer:** koude pageload onder een seconde, één enkel JS-bestand per
 module, geen externe requests, thema klopt automatisch, werkt op de telefoon.

--- a/docs/legacy-notes.md
+++ b/docs/legacy-notes.md
@@ -157,6 +157,23 @@ Samen 887 regels.
 Samen 1266 regels. `css/styles.css` is het grootste bestand van de hele repo en
 heeft geen enkele `<link>` of import.
 
+**Correctie 28-07-2026 — Lovelace-resources.** De twee tabellen hierboven
+beschrijven het **binnenste** document (de iframe met `index.html`). In HA zelf
+stonden daarnaast twee resource-registraties, buiten de repo om:
+
+| Resource | Type |
+|---|---|
+| `/local/chores-dashboard/js/components.js` | JavaScript-module |
+| `/local/chores-dashboard/js/utils.js` | JavaScript-module |
+
+Daardoor werden die twee bestanden ook in het **buitenste** HA-document geladen,
+op élk dashboard. `js/components.js` was dus niet "nooit geladen" maar
+buiten-wel/binnen-niet, en `js/utils.js` werd dubbel geladen: binnen via
+`index.html` én buiten als resource. Voor de classificatie binnen het eigen
+document blijven de tabellen kloppen. Beide registraties zijn op 28-07-2026
+verwijderd; sindsdien geldt de oorspronkelijke lezing alsnog, en kunnen beide
+bestanden zonder 404-risico weg.
+
 ---
 
 ## 3. Bekende gebreken op het moment van vastleggen
@@ -191,6 +208,29 @@ Die listener heeft nooit gevuurd.
 
 **Twee geneste iframes.** `panel.py:28` staat op `embed_iframe: True`, en
 `chores-dashboard.js:77` bouwt daarbinnen nog een eigen iframe.
+
+**De panelroute `/chores` is kapot en was dat altijd al.** (Vastgesteld
+28-07-2026.) De binnenste iframe in `chores-dashboard.js` is een direct kind
+van de shadow root (regel 24, `this.shadowRoot.innerHTML`), en voor een direct
+kind van een ShadowRoot is `parentElement` **null** — dat geeft alleen
+Element-ouders terug, en een ShadowRoot is een DocumentFragment. De inline
+handlers gebruiken hem toch:
+
+- regel 81, `onload`: `this.parentElement.querySelector('#loading')…` gooit
+  `TypeError: can't access property querySelector, this.parentElement is null`.
+  Het tweede statement — `this.style.display='block'` — draait daardoor nooit,
+  dus de iframe blijft op zijn inline `display: none` van regel 80 staan.
+- regel 82, `onerror`: identieke bug.
+
+Gevolg: de app laadt en draait volledig, maar onzichtbaar. De laadindicator
+wordt nooit opgeruimd, dus de timeout op regels 91-102 vuurt na 15 seconden en
+toont "Dashboard is taking longer than expected to load". Ironisch genoeg doen
+regels 87-88 het in dezelfde functie wél goed (`this.shadowRoot.querySelector`);
+`parentNode` had in de handlers ook gewerkt.
+
+Bewust niet gerepareerd: `chores-dashboard.js` verdwijnt in fase 3 samen met
+`embed_iframe: True`. Tot die tijd is het Lovelace-dashboard
+`/dashboard-chores/taken` de enige werkende ingang.
 
 **Externe afhankelijkheden.** `index.html:15` laadt Tailwind van
 `cdn.tailwindcss.com`, `index.html:150-151` laden React en ReactDOM van

--- a/docs/legacy-state.yaml
+++ b/docs/legacy-state.yaml
@@ -1,0 +1,348 @@
+# Fase 0-referentie (REFACTOR_PLAN.md §9): momentopname van
+# sensor.chores_overview, uitgelezen via HA Developer Tools op 28-07-2026.
+# De opnamedag volgt uit de data zelf: next_due_date - days_until_due komt
+# voor alle acht taken op 2026-07-28 uit (zie tests/test_legacy_tasks.py).
+#
+# De data wordt niet gemigreerd (§3); dit bestand is het naslagpunt voor hoe
+# de acht taken bedoeld waren — inclusief de zes overlappende planningsvelden
+# (frequency_type, frequency_days, frequency_times, weekday, monthday,
+# active_days) waar het oude schema aan stuk ging.
+#
+# Aangeleverd door Martijn, inhoudelijk ongewijzigd overgenomen; alleen de
+# indentatie is hersteld, want de attributenweergave van HA plakt geneste
+# blokken plat.
+#
+# Let op bij het lezen: legacy telt weekdagen 0-based vanaf maandag
+# (weekday 2 = woensdag, weekday 5 = zaterdag). Het v2-model gebruikt
+# ISO-weekdagen 1-7.
+entity_id: sensor.chores_overview
+friendly_name: Chores Overview
+state: '0'
+attributes:
+  state_class: measurement
+  overdue_tasks:
+  - id: wasmachine
+    name: Was draaien
+    frequency_type: Dagelijks
+    frequency_days: 7
+    frequency_times: 1
+    assigned_to: Laura
+    priority: Middel
+    duration: 20
+    last_done: '2025-10-18T15:06:08.057921'
+    last_done_by: Laura
+    icon: 👕
+    description: 'Voor 19:00'
+    alternate_with: ''
+    use_alternating: 0
+    startMonth: 0
+    startDay: 1
+    weekday: -1
+    monthday: -1
+    notify_when_due: 0
+    active_days: '{"mon": true, "tue": true, "wed": true, "thu": true, "fri": true, "sat": true, "sun": true}'
+    active_monthdays: null
+    has_subtasks: 0
+    subtasks_completion_type: all
+    subtasks_streak_type: period
+    subtasks_period: week
+    subtasks: []
+    chore_id: wasmachine
+    days_since: 282
+    next_due_date: '2025-10-19'
+    is_due_today: true
+    is_overdue: true
+    days_until_due: -282
+    subtasks_completed_count: 0
+    subtasks_total_count: 0
+  - id: planten
+    name: Planten water geven
+    frequency_type: Meerdere keren per week
+    frequency_days: 7
+    frequency_times: 1
+    assigned_to: Wie kan
+    priority: Middel
+    duration: 5
+    last_done: '2025-10-25T11:18:18.714577'
+    last_done_by: Laura
+    icon: 🌱
+    description: ''
+    alternate_with: ''
+    use_alternating: 0
+    startMonth: 0
+    startDay: 1
+    weekday: 6
+    monthday: -1
+    notify_when_due: 0
+    active_days: '{"mon": false, "tue": false, "wed": true, "thu": false, "fri": false, "sat": false, "sun": true}'
+    active_monthdays: null
+    has_subtasks: 0
+    subtasks_completion_type: all
+    subtasks_streak_type: period
+    subtasks_period: week
+    subtasks: []
+    chore_id: planten
+    days_since: 276
+    next_due_date: '2025-10-26'
+    is_due_today: true
+    is_overdue: true
+    days_until_due: -275
+    subtasks_completed_count: 0
+    subtasks_total_count: 0
+  - id: vaatwasser_in-_en_uitruimen
+    name: Keuken opruimen
+    frequency_type: Dagelijks
+    frequency_days: 7
+    frequency_times: 1
+    assigned_to: Martijn
+    priority: Middel
+    duration: 20
+    last_done: '2025-10-25T11:17:59.237013'
+    last_done_by: Martijn
+    icon: 🍽️
+    description: ''
+    alternate_with: Wie kan
+    use_alternating: 0
+    startMonth: 0
+    startDay: 1
+    weekday: -1
+    monthday: -1
+    notify_when_due: 0
+    active_days: null
+    active_monthdays: null
+    has_subtasks: 0
+    subtasks_completion_type: all
+    subtasks_streak_type: period
+    subtasks_period: week
+    subtasks: []
+    chore_id: vaatwasser_in-_en_uitruimen
+    days_since: 276
+    next_due_date: '2025-10-26'
+    is_due_today: true
+    is_overdue: true
+    days_until_due: -275
+    subtasks_completed_count: 0
+    subtasks_total_count: 0
+  - id: ah_boodschappenlijst_maken
+    name: AH Boodschappenlijst maken
+    frequency_type: Wekelijks
+    frequency_days: 7
+    frequency_times: 1
+    assigned_to: Martijn
+    priority: Middel
+    duration: 30
+    last_done: '2025-10-25T11:18:26.975234'
+    last_done_by: Laura
+    icon: 🛒
+    description: ''
+    alternate_with: Laura
+    use_alternating: 1
+    startMonth: 0
+    startDay: 1
+    weekday: 2
+    monthday: -1
+    notify_when_due: 0
+    active_days: null
+    active_monthdays: null
+    has_subtasks: 0
+    subtasks_completion_type: all
+    subtasks_streak_type: period
+    subtasks_period: week
+    subtasks: []
+    chore_id: ah_boodschappenlijst_maken
+    days_since: 276
+    next_due_date: '2025-10-29'
+    is_due_today: true
+    is_overdue: true
+    days_until_due: -272
+    subtasks_completed_count: 0
+    subtasks_total_count: 0
+  - id: apparatuur_onderhoud
+    name: Apparatuur onderhoud
+    frequency_type: Wekelijks
+    frequency_days: 7
+    frequency_times: 1
+    assigned_to: Martijn
+    priority: Middel
+    duration: 30
+    last_done: '2026-01-28T16:49:03.815791'
+    last_done_by: Martijn
+    icon: 📋
+    description: ''
+    alternate_with: ''
+    use_alternating: 0
+    startMonth: 0
+    startDay: 1
+    weekday: 5
+    monthday: -1
+    notify_when_due: 0
+    active_days: null
+    active_monthdays: null
+    has_subtasks: 0
+    subtasks_completion_type: all
+    subtasks_streak_type: period
+    subtasks_period: week
+    subtasks: []
+    chore_id: apparatuur_onderhoud
+    days_since: 180
+    next_due_date: '2026-01-31'
+    is_due_today: true
+    is_overdue: true
+    days_until_due: -178
+    subtasks_completed_count: 0
+    subtasks_total_count: 0
+  - id: lunch_trommels_vullen
+    name: Lunch trommels vullen
+    frequency_type: Wekelijks
+    frequency_days: 7
+    frequency_times: 5
+    assigned_to: Wie kan
+    priority: Middel
+    duration: 15
+    last_done: '2026-01-28T16:49:11.292893'
+    last_done_by: Laura
+    icon: 🍲
+    description: ''
+    alternate_with: Wie kan
+    use_alternating: 0
+    startMonth: 0
+    startDay: 1
+    weekday: -1
+    monthday: -1
+    notify_when_due: 0
+    active_days: '{"mon": true, "tue": true, "wed": true, "thu": true, "fri": true, "sat": false, "sun": false}'
+    active_monthdays: null
+    has_subtasks: 0
+    subtasks_completion_type: all
+    subtasks_streak_type: period
+    subtasks_period: week
+    subtasks: []
+    chore_id: lunch_trommels_vullen
+    days_since: 180
+    next_due_date: '2026-02-04'
+    is_due_today: true
+    is_overdue: true
+    days_until_due: -174
+    subtasks_completed_count: 0
+    subtasks_total_count: 0
+  - id: vriezer_ontdooien
+    name: Vriezer keuken ontdooien
+    frequency_type: Halfjaarlijks
+    frequency_days: 180
+    frequency_times: 1
+    assigned_to: Laura
+    priority: Middel
+    duration: 30
+    last_done: '2025-10-04T16:23:51.242854'
+    last_done_by: Laura
+    icon: 🧊
+    description: ''
+    alternate_with: Wie kan
+    use_alternating: 0
+    startMonth: 6
+    startDay: 15
+    weekday: -1
+    monthday: -1
+    notify_when_due: 0
+    active_days: null
+    active_monthdays: null
+    has_subtasks: 0
+    subtasks_completion_type: all
+    subtasks_streak_type: period
+    subtasks_period: week
+    subtasks: []
+    chore_id: vriezer_ontdooien
+    days_since: 296
+    next_due_date: '2026-04-04'
+    is_due_today: true
+    is_overdue: true
+    days_until_due: -115
+    subtasks_completed_count: 0
+    subtasks_total_count: 0
+  - id: afzuigkap_koolstoffilter_wassen
+    name: Afzuigkap koolstoffilter wassen
+    frequency_type: Halfjaarlijks
+    frequency_days: 180
+    frequency_times: 1
+    assigned_to: Martijn
+    priority: Middel
+    duration: 15
+    last_done: '2025-10-18T15:06:30.392916'
+    last_done_by: Martijn
+    icon: 💨
+    description: |2-
+        *   Filter en houder losmaken en in vaatwasser op heetste (70 graden - P3) programma.
+        *   Randjes aan binnenkant afzuigkap schoonmaken.
+        *   Wanneer vaatwasser klaar het koolstoffilter in een voorverwarmde oven leggen op 80 graden voor 10 minuten.
+        *   Terugplaatsen filter in houder en terugplaatsen in afzuigkap.
+    alternate_with: Wie kan
+    use_alternating: 0
+    startMonth: 6
+    startDay: 1
+    weekday: -1
+    monthday: -1
+    notify_when_due: 0
+    active_days: null
+    active_monthdays: null
+    has_subtasks: 0
+    subtasks_completion_type: all
+    subtasks_streak_type: period
+    subtasks_period: week
+    subtasks: []
+    chore_id: afzuigkap_koolstoffilter_wassen
+    days_since: 282
+    next_due_date: '2026-04-18'
+    is_due_today: true
+    is_overdue: true
+    days_until_due: -101
+    subtasks_completed_count: 0
+    subtasks_total_count: 0
+  stats:
+    Laura:
+      tasks_completed: 0
+      time_completed: 0
+      total_tasks: 2
+      total_time: 50
+      streak: 0
+      monthly_completed: 0
+      monthly_percentage: 0
+      due_tasks: []
+    Martijn:
+      tasks_completed: 0
+      time_completed: 0
+      total_tasks: 4
+      total_time: 95
+      streak: 0
+      monthly_completed: 0
+      monthly_percentage: 0
+      due_tasks: []
+  assignees:
+  - id: laura
+    name: Laura
+    color: '#83c44a'
+    active: 1
+    ha_user_id: null
+  - id: martijn
+    name: Martijn
+    color: '#4dd8ff'
+    active: 1
+    ha_user_id: null
+  - id: noud
+    name: Noud
+    color: '#013589'
+    active: 1
+    ha_user_id: null
+  - id: wie_kan
+    name: Wie kan
+    color: '#ff8000'
+    active: 1
+    ha_user_id: null
+  completed_today: 0
+  theme_settings:
+    backgroundColor: '#ffffff'
+    cardColor: '#f8f8f8'
+    primaryTextColor: '#000000'
+    secondaryTextColor: '#333333'
+  unit_of_measurement: tasks
+  icon: mdi:clipboard-check
+  friendly_name: Chores Overview


### PR DESCRIPTION
Drie plancorrecties na de verificatie van fase 1, vóór de start van fase 2a. Alleen documentatie; geen code.

## Sequencing (§9)

Fase 2 en 3 leven voortaan op één branch, `refactor/v2`, en gaan pas sámen naar main. Fase 2 vervangt het schema en slankt de sensor af, waardoor de huidige frontend — die `overdue_tasks` uit de sensorattributen leest — breekt voordat fase 3 hem vervangt. Main houdt dus de werkende oude app tot het geheel af is.

Fase 2 is gesplitst in **2a** (schema, verbindingslaag, planningslogica, tests — zelfstandig met pytest verifieerbaar, sluit nergens op HA aan) en **2b** (WebSocket, sensor, scheduler, ontmanteling van `database.py` en de oude DDL). In fase 2 verdwijnen alleen de twee onbereikbare Python-bestanden (`services.py`, `utils.py`); alles onder `www/` blijft staan tot fase 3.

## Lovelace-resources (§7, legacy-notes)

In HA stonden twee resource-registraties buiten de repo om: `/local/chores-dashboard/js/components.js` en `/local/chores-dashboard/js/utils.js`, beide als JavaScript-module, geladen in het buitenste HA-document op élk dashboard. Dat corrigeert de eerdere classificatie: `js/components.js` was buiten-wel/binnen-niet geladen, en `js/utils.js` dubbel. De registraties zijn op 28-07-2026 verwijderd; beide bestanden kunnen nu zonder 404-risico geschrapt worden.

## De panelroute `/chores` is kapot en was dat altijd al (legacy-notes, §9 fase 3)

Bevestigd op regelniveau: de binnenste iframe in `chores-dashboard.js` is een direct kind van de shadow root (regel 24), en voor directe kinderen van een ShadowRoot is `parentElement` null. De inline `onload`-handler op **regel 81** (`this.parentElement.querySelector('#loading')…`) gooit daardoor de TypeError; het tweede statement — dat de iframe zichtbaar zou maken — draait nooit, dus de iframe blijft op zijn `display: none` van regel 80 staan. Regel 82 (`onerror`) heeft dezelfde bug. De laadindicator wordt nooit opgeruimd en de 15s-timeout (regels 91-102) toont "Dashboard is taking longer than expected to load" terwijl de app onzichtbaar draait.

Bewust niet gerepareerd: `chores-dashboard.js` verdwijnt in fase 3 samen met `embed_iframe: True`. In §9 fase 3 is vastgelegd dat `/dashboard-chores/taken` de enige werkende ingang is en pas mag verdwijnen als het nieuwe panel draait.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYXAm5rwQW1aLnAaNtL1Zh)_