### PR TITLE
fix(panel): tabnavigatie — HA-router onderschept ankerkliks

### DIFF
--- a/custom_components/chores_manager/panel_v2.py
+++ b/custom_components/chores_manager/panel_v2.py
@@ -25,7 +25,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PANEL_VERSION = "2.1.0-20260728-fase3b"
+PANEL_VERSION = "2.1.1-20260728-fase3b"
 FRONTEND_URL_PATH = "taken"
 STATIC_URL = "/chores_manager-panel"
 _DATA_STATIC_REGISTERED = "v2_panel_static_registered"

--- a/custom_components/chores_manager/www/chores-panel/chores-panel.js
+++ b/custom_components/chores_manager/www/chores-panel/chores-panel.js
@@ -4,6 +4,15 @@
  * Vier weergaven (Vandaag, Alles, Activiteit, Beheer) achter tabs; de actieve
  * weergave staat in de URL-hash zodat een refresh je niet terugzet.
  *
+ * ROUTERVALKUIL: de HA-frontend onderschept elke klik op een <a> (ook door
+ * shadow DOM heen) en vertaalt hem naar history.pushState() — en pushState
+ * vuurt géén hashchange. Daarom krijgt de tabklik hier een preventDefault en
+ * zetten we de hash zelf: dat ís een echte hashnavigatie. Eén handler op
+ * window luistert naar hashchange én naar HA's location-changed (het event
+ * dat HA na een pushState uitstuurt) en triggert de render; hij is
+ * idempotent, zodat dubbele events (terugknop vuurt beide) een open
+ * formulier niet wissen.
+ *
  * BELANGRIJKE VALKUIL — de hass-setter:
  * Home Assistant zet de hass-property bij ELKE state-change in het hele
  * systeem, mogelijk vele keren per seconde. In die setter renderen maakt het
@@ -21,17 +30,17 @@
  * Versiediscipline: de ?v= in elke import spiegelt PANEL_VERSION in
  * panel_v2.py. Zie CLAUDE.md.
  */
-import { api } from './core/api.js?v=2.1.0-20260728-fase3b';
-import { store } from './core/store.js?v=2.1.0-20260728-fase3b';
-import { html, setContent } from './core/html.js?v=2.1.0-20260728-fase3b';
-import { renderToday } from './views/today.js?v=2.1.0-20260728-fase3b';
-import { renderTasks } from './views/tasks.js?v=2.1.0-20260728-fase3b';
-import { renderActivity } from './views/activity.js?v=2.1.0-20260728-fase3b';
-import { renderManage, collectAssigneeForm } from './views/manage.js?v=2.1.0-20260728-fase3b';
-import { collectChoreForm } from './components/task-form.js?v=2.1.0-20260728-fase3b';
-import { isFinalAction } from './components/task-card.js?v=2.1.0-20260728-fase3b';
+import { api } from './core/api.js?v=2.1.1-20260728-fase3b';
+import { store } from './core/store.js?v=2.1.1-20260728-fase3b';
+import { html, setContent } from './core/html.js?v=2.1.1-20260728-fase3b';
+import { renderToday } from './views/today.js?v=2.1.1-20260728-fase3b';
+import { renderTasks } from './views/tasks.js?v=2.1.1-20260728-fase3b';
+import { renderActivity } from './views/activity.js?v=2.1.1-20260728-fase3b';
+import { renderManage, collectAssigneeForm } from './views/manage.js?v=2.1.1-20260728-fase3b';
+import { collectChoreForm } from './components/task-form.js?v=2.1.1-20260728-fase3b';
+import { isFinalAction } from './components/task-card.js?v=2.1.1-20260728-fase3b';
 
-const VERSION = '2.1.0-20260728-fase3b';
+const VERSION = '2.1.1-20260728-fase3b';
 const STATIC_BASE = '/chores_manager-panel';
 
 const TABS = [
@@ -73,7 +82,7 @@ class ChoresPanel extends HTMLElement {
     this._onClick = this._onClick.bind(this);
     this._onSubmit = this._onSubmit.bind(this);
     this._onChange = this._onChange.bind(this);
-    this._onHashChange = this._onHashChange.bind(this);
+    this._onLocationChanged = this._onLocationChanged.bind(this);
   }
 
   /** Zie de valkuil in de kop: hier alleen bewaren, nooit renderen. */
@@ -103,13 +112,17 @@ class ChoresPanel extends HTMLElement {
       root.addEventListener('submit', this._onSubmit);
       root.addEventListener('change', this._onChange);
     }
-    window.addEventListener('hashchange', this._onHashChange);
+    // Beide events: hashchange voor echte hashnavigatie (tabklik, terugknop),
+    // location-changed voor HA's pushState-navigatie (zie de kop).
+    window.addEventListener('hashchange', this._onLocationChanged);
+    window.addEventListener('location-changed', this._onLocationChanged);
     if (this._hass && !this._started) this._start();
   }
 
   disconnectedCallback() {
     this._started = false;
-    window.removeEventListener('hashchange', this._onHashChange);
+    window.removeEventListener('hashchange', this._onLocationChanged);
+    window.removeEventListener('location-changed', this._onLocationChanged);
     api.unsubscribe();
     if (this._unsubStore) {
       this._unsubStore();
@@ -152,12 +165,34 @@ class ChoresPanel extends HTMLElement {
     setContent(this._app, html`${renderNav(state.view)}${body}`);
   }
 
-  _onHashChange() {
-    store.set({ view: viewFromHash(), chooser: null, editing: null });
+  /**
+   * Eén plek die de URL naar de weergave vertaalt. Idempotent: de terugknop
+   * vuurt hashchange én location-changed, en HA's setter-verkeer mag een open
+   * formulier niet wissen als de weergave niet echt wisselt.
+   */
+  _onLocationChanged() {
+    const view = viewFromHash();
+    if (view === store.get().view) return;
+    store.set({ view, chooser: null, editing: null });
   }
 
   async _onClick(event) {
-    const button = event.composedPath().find(
+    const path = event.composedPath();
+
+    // Tabklik: alleen de hash zetten, verder niets. Zonder preventDefault
+    // maakt de HA-router er een pushState van en vuurt hashchange nooit.
+    const tab = path.find(
+      (el) => el instanceof HTMLElement && el.classList?.contains('tab'));
+    if (tab) {
+      event.preventDefault();
+      const target = tab.getAttribute('href');
+      if (target && target !== window.location.hash) {
+        window.location.hash = target;
+      }
+      return;
+    }
+
+    const button = path.find(
       (el) => el instanceof HTMLElement && el.dataset && el.dataset.action);
     if (!button || button.disabled) return;
     const { action } = button.dataset;

--- a/custom_components/chores_manager/www/chores-panel/components/contribution-bar.js
+++ b/custom_components/chores_manager/www/chores-panel/components/contribution-bar.js
@@ -9,8 +9,8 @@
  * kind doet niet mee in de tijdsranglijst van volwassenen, maar zijn minuten
  * kleuren wél de balk).
  */
-import { html } from '../core/html.js?v=2.1.0-20260728-fase3b';
-import { formatDuration, taskCount } from '../core/format.js?v=2.1.0-20260728-fase3b';
+import { html } from '../core/html.js?v=2.1.1-20260728-fase3b';
+import { formatDuration, taskCount } from '../core/format.js?v=2.1.1-20260728-fase3b';
 
 export function renderContributionBar(leaderboard) {
   const total = leaderboard.total_minutes;

--- a/custom_components/chores_manager/www/chores-panel/components/task-card.js
+++ b/custom_components/chores_manager/www/chores-panel/components/task-card.js
@@ -13,13 +13,13 @@
  * Op het scherm Alles (ctx.view 'tasks') toont de kaart vervaldatum en
  * planningsetiket, en staat de checklist ingeklapt achter "0 / 4 stappen".
  */
-import { html } from '../core/html.js?v=2.1.0-20260728-fase3b';
+import { html } from '../core/html.js?v=2.1.1-20260728-fase3b';
 import {
   dueLabel,
   formatDuration,
   overdueLabel,
   scheduleLabel,
-} from '../core/format.js?v=2.1.0-20260728-fase3b';
+} from '../core/format.js?v=2.1.1-20260728-fase3b';
 
 /**
  * Maakt deze actie de taak in één keer af? Bepaalt of we optimistisch mogen

--- a/custom_components/chores_manager/www/chores-panel/components/task-form.js
+++ b/custom_components/chores_manager/www/chores-panel/components/task-form.js
@@ -8,7 +8,7 @@
  * tonen/verbergen gebeurt in de DOM (data-switch in chores-panel.js), zonder
  * re-render, zodat ingevuld werk blijft staan.
  */
-import { esc, html } from '../core/html.js?v=2.1.0-20260728-fase3b';
+import { esc, html } from '../core/html.js?v=2.1.1-20260728-fase3b';
 
 const WEEKDAY_OPTIONS = [
   [1, 'maandag'], [2, 'dinsdag'], [3, 'woensdag'], [4, 'donderdag'],

--- a/custom_components/chores_manager/www/chores-panel/views/activity.js
+++ b/custom_components/chores_manager/www/chores-panel/views/activity.js
@@ -5,13 +5,13 @@
  * nooit achterlopen. De weekhistorie toont iedereen die iets deed — feiten;
  * het ranglijstfilter geldt alleen de lopende week op Vandaag.
  */
-import { html } from '../core/html.js?v=2.1.0-20260728-fase3b';
+import { html } from '../core/html.js?v=2.1.1-20260728-fase3b';
 import {
   feedWhen,
   formatDuration,
   taskCount,
   weekTitle,
-} from '../core/format.js?v=2.1.0-20260728-fase3b';
+} from '../core/format.js?v=2.1.1-20260728-fase3b';
 
 function feedRow(row, todayIso) {
   return html`

--- a/custom_components/chores_manager/www/chores-panel/views/manage.js
+++ b/custom_components/chores_manager/www/chores-panel/views/manage.js
@@ -6,9 +6,9 @@
  * Activiteit), zonder historie gaat hij echt weg. Personen idem, inclusief
  * rotatielidmaatschap.
  */
-import { html } from '../core/html.js?v=2.1.0-20260728-fase3b';
-import { scheduleLabel } from '../core/format.js?v=2.1.0-20260728-fase3b';
-import { renderChoreForm, slugify } from '../components/task-form.js?v=2.1.0-20260728-fase3b';
+import { html } from '../core/html.js?v=2.1.1-20260728-fase3b';
+import { scheduleLabel } from '../core/format.js?v=2.1.1-20260728-fase3b';
+import { renderChoreForm, slugify } from '../components/task-form.js?v=2.1.1-20260728-fase3b';
 
 function choreRow(chore) {
   return html`

--- a/custom_components/chores_manager/www/chores-panel/views/tasks.js
+++ b/custom_components/chores_manager/www/chores-panel/views/tasks.js
@@ -5,9 +5,9 @@
  * taak de volgende vervaldatum en het planningsetiket (via ctx.view 'tasks'
  * in de taakkaart); checklists staan hier ingeklapt achter "0 / 4 stappen".
  */
-import { html } from '../core/html.js?v=2.1.0-20260728-fase3b';
-import { taskCount } from '../core/format.js?v=2.1.0-20260728-fase3b';
-import { renderTaskCard } from '../components/task-card.js?v=2.1.0-20260728-fase3b';
+import { html } from '../core/html.js?v=2.1.1-20260728-fase3b';
+import { taskCount } from '../core/format.js?v=2.1.1-20260728-fase3b';
+import { renderTaskCard } from '../components/task-card.js?v=2.1.1-20260728-fase3b';
 
 function endOfWeekIso(todayIso) {
   const d = new Date(`${todayIso}T12:00:00`);

--- a/custom_components/chores_manager/www/chores-panel/views/today.js
+++ b/custom_components/chores_manager/www/chores-panel/views/today.js
@@ -6,10 +6,10 @@
  * tellers (§2.4). Taken in `pending` zijn optimistisch afgevinkt en blijven
  * uit beeld tot de server het bevestigt of het terugdraait.
  */
-import { html } from '../core/html.js?v=2.1.0-20260728-fase3b';
-import { dateLong, feedWhen, formatDuration, taskCount } from '../core/format.js?v=2.1.0-20260728-fase3b';
-import { renderContributionBar } from '../components/contribution-bar.js?v=2.1.0-20260728-fase3b';
-import { renderTaskCard } from '../components/task-card.js?v=2.1.0-20260728-fase3b';
+import { html } from '../core/html.js?v=2.1.1-20260728-fase3b';
+import { dateLong, feedWhen, formatDuration, taskCount } from '../core/format.js?v=2.1.1-20260728-fase3b';
+import { renderContributionBar } from '../components/contribution-bar.js?v=2.1.1-20260728-fase3b';
+import { renderTaskCard } from '../components/task-card.js?v=2.1.1-20260728-fase3b';
 
 const FEED_ROWS = 5;
 


### PR DESCRIPTION
De tabs deden niets tot een F5: de hashchange-listener stond wel op window, maar vuurde nooit. De HA-frontend onderschept elke klik op een <a> (ook door shadow DOM heen, via composedPath) en vertaalt hem naar history.pushState() — en pushState vuurt geen hashchange.

De fix in twee lagen:
- De tabklik krijgt preventDefault en zet alleen zelf de hash; dat is een echte hashnavigatie, dus hashchange vuurt gewoon.
- Eén window-handler (_onLocationChanged) luistert naar hashchange én HA's location-changed en vertaalt de URL naar de weergave. Hij is idempotent: de terugknop vuurt beide events, en een dubbele afhandeling mag een open formulier niet wissen.

Versie 2.1.0 → 2.1.1-20260728-fase3b (PANEL_VERSION + 26 ?v=-literals, één sed, consistentie gecontroleerd). node --check groen op alle panelbestanden; pytest 182 geslaagd.


Claude-Session: https://claude.ai/code/session_01JYXAm5rwQW1aLnAaNtL1Zh