### PR TITLE
feat: fase 4 — koppelen en herinneren (2.3.0)

### DIFF
--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -454,11 +454,17 @@ persoon is er niets om naartoe te sturen.
 | Zondag 20:00 | Weeksamenvatting met de uitslag en de streaks |
 
 Notificaties zijn **actionable**: een knop "Klaar" in de melding vinkt de taak af
-via `mobile_app_notification_action` → `chores_manager.mark_done`. Dat is wat
-"makkelijk te beheren" in de praktijk betekent — afvinken zonder de app te openen.
+via `mobile_app_notification_action`. Dat is wat "makkelijk te beheren" in de
+praktijk betekent — afvinken zonder de app te openen. *(Gecorrigeerd in fase 4:
+de oorspronkelijke tekst noemde `chores_manager.mark_done`, maar die service is
+in 3c met de oude app verdwenen. De listener in `notify.py` vangt het event en
+roept dezelfde db-functie aan als het panel, met dezelfde undo-buffer en
+hetzelfde dispatchersignaal. Taak en ontvanger zitten in de action-string:
+`chores_manager_complete:<chore_id>:<assignee_id>`.)*
 
-Aan/uit per persoon, niet per taak. De huidige `notify_when_due`-vlag per taak is
-een instelling die niemand ooit aanzet.
+Aan/uit per persoon, niet per taak (kolom `notifications_enabled`, fase 4;
+standaard aan). De oude `notify_when_due`-vlag per taak was een instelling die
+niemand ooit aanzette.
 
 ---
 
@@ -825,6 +831,16 @@ resource-URL), themakeuze per apparaat in Beheer, `manifest.json` 2.2.0 met
 
 **Klaar wanneer:** je krijgt 's ochtends een melding, kunt vanuit die melding
 afvinken, en ziet zondagavond de weekuitslag.
+
+**Status: gebouwd op 28-07-2026.** Koppelvelden (HA-gebruiker via
+person-entiteiten, meldingsservice met vrij veld, meldingen aan/uit) in het
+personenformulier; chip-default op de ingelogde gebruiker bij 'anyone'-taken;
+`notify.py` met de ochtendmelding (08:00, alleen wie iets te doen heeft, één
+"Klaar"-knop), de weeksamenvatting (zondag 20:00, samen eerst) en de
+action-listener. Tijden als constanten in `const.py` (fase 5: instelbaar).
+Testservices `send_daily_summary`/`send_weekly_summary` (tijdelijk, net als
+seed). Nog open uit deze fase: niets — de automation-opruiming hierboven is
+werk in de HA-config zelf, geen repowerk.
 
 ### Fase 5 — Aanscherpen (1–2 dagen)
 

--- a/custom_components/chores_manager/__init__.py
+++ b/custom_components/chores_manager/__init__.py
@@ -6,6 +6,7 @@ Sinds fase 3c is dit de enige app. De opzet is klein gehouden:
 - negen WS-commando's (websocket.py) met push via de dispatcher;
 - één overzichtssensor (sensor.py), zonder polling;
 - nachtelijke rol om 03:00 (scheduler.py);
+- meldingen om 08:00 en zondag 20:00 plus de "Klaar"-knop (notify.py, fase 4);
 - het panel op /taken (panel.py), rechtstreeks geserveerd uit deze map.
 
 De oude app (React-dashboard onder www/, eigen tokens, twintig services) is
@@ -22,6 +23,7 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     DATA_DB_PATH,
+    DATA_UNSUB_NOTIFY,
     DATA_UNSUB_ROLL,
     DATA_WS_REGISTERED,
     DB_FILENAME,
@@ -30,6 +32,7 @@ from .const import (
     SIGNAL_UPDATED,
 )
 from .db.schema import create_database
+from .notify import async_send_daily, async_send_weekly, async_setup_notifications
 from .panel import async_remove_panel, async_setup_panel
 from .scheduler import async_run_roll, async_setup_scheduler
 from .seed import seed_v2
@@ -59,6 +62,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     domain_data[entry.entry_id][DATA_UNSUB_ROLL] = async_setup_scheduler(
         hass, database_path)
 
+    # meldingen (fase 4): 08:00, zondag 20:00 en de "Klaar"-knop
+    domain_data[entry.entry_id][DATA_UNSUB_NOTIFY] = async_setup_notifications(
+        hass, database_path)
+
     await async_setup_panel(hass)
 
     async def handle_seed(call: ServiceCall) -> None:
@@ -73,8 +80,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """De nachtelijke rol nu draaien, zonder op 03:00 te wachten."""
         await async_run_roll(hass, database_path)
 
+    async def handle_send_daily(call: ServiceCall) -> None:
+        """TIJDELIJK (net als seed): de ochtendmelding nu versturen."""
+        verzonden = await async_send_daily(hass, database_path)
+        _LOGGER.info("Chores Manager: send_daily_summary → %d meldingen", verzonden)
+
+    async def handle_send_weekly(call: ServiceCall) -> None:
+        """TIJDELIJK (net als seed): de weeksamenvatting nu versturen."""
+        verzonden = await async_send_weekly(hass, database_path)
+        _LOGGER.info("Chores Manager: send_weekly_summary → %d meldingen", verzonden)
+
     hass.services.async_register(DOMAIN, "seed", handle_seed)
     hass.services.async_register(DOMAIN, "roll_forward", handle_roll)
+    hass.services.async_register(DOMAIN, "send_daily_summary", handle_send_daily)
+    hass.services.async_register(DOMAIN, "send_weekly_summary", handle_send_weekly)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     _LOGGER.info("Chores Manager: setup compleet")
@@ -86,11 +105,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async_remove_panel(hass)
 
     entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
-    unsub = entry_data.pop(DATA_UNSUB_ROLL, None)
-    if unsub:
-        unsub()
+    for key in (DATA_UNSUB_ROLL, DATA_UNSUB_NOTIFY):
+        unsub = entry_data.pop(key, None)
+        if unsub:
+            unsub()
 
-    for service in ("seed", "roll_forward"):
+    for service in ("seed", "roll_forward",
+                    "send_daily_summary", "send_weekly_summary"):
         if hass.services.has_service(DOMAIN, service):
             hass.services.async_remove(DOMAIN, service)
 

--- a/custom_components/chores_manager/const.py
+++ b/custom_components/chores_manager/const.py
@@ -18,8 +18,23 @@ SIGNAL_UPDATED = "chores_manager_updated"
 # Undo-venster (§2.3): laatste voltooiing terugdraaien binnen 5 minuten.
 UNDO_WINDOW_SECONDS = 300
 
+# Meldingstijden (§6). Vast in fase 4; fase 5 kan ze instelbaar maken.
+# Volgorde-afhankelijkheid: de rol van 03:00 (scheduler.py) draait vóór de
+# ochtendmelding — die leest gewoon de dan actuele staat, maar zet je de
+# melding ooit vóór de rol, dan meldt hij gisteren.
+MORNING_HOUR = 8
+MORNING_MINUTE = 0
+WEEKLY_DAY = 6  # maandag = 0, dus 6 = zondag
+WEEKLY_HOUR = 20
+WEEKLY_MINUTE = 0
+
+# Prefix van de action-string achter de "Klaar"-knop (notify.py):
+# "<prefix>:<chore_id>:<assignee_id>". Ids zijn slugs zonder dubbele punt.
+NOTIFY_ACTION_PREFIX = "chores_manager_complete"
+
 # Sleutels in hass.data[DOMAIN]
 DATA_DB_PATH = "db_path"
 DATA_UNDO = "undo"
 DATA_WS_REGISTERED = "ws_registered"
 DATA_UNSUB_ROLL = "unsub_roll"
+DATA_UNSUB_NOTIFY = "unsub_notify"

--- a/custom_components/chores_manager/db/assignees.py
+++ b/custom_components/chores_manager/db/assignees.py
@@ -39,6 +39,7 @@ def save_assignee(database_path: str, data: dict) -> dict:
 
     fields = (
         name, color, data.get("ha_user_id"), data.get("notify_service"),
+        1 if data.get("notifications_enabled", 1) else 0,
         1 if data.get("active", 1) else 0,
         1 if data.get("include_in_leaderboard", 1) else 0,
         data.get("sort_order", 0),
@@ -49,13 +50,14 @@ def save_assignee(database_path: str, data: dict) -> dict:
         if existing:
             conn.execute(
                 "UPDATE assignees SET name=?, color=?, ha_user_id=?, notify_service=?,"
-                " active=?, include_in_leaderboard=?, sort_order=? WHERE id=?",
+                " notifications_enabled=?, active=?, include_in_leaderboard=?,"
+                " sort_order=? WHERE id=?",
                 fields + (assignee_id,))
         else:
             conn.execute(
                 "INSERT INTO assignees (name, color, ha_user_id, notify_service,"
-                " active, include_in_leaderboard, sort_order, id)"
-                " VALUES (?,?,?,?,?,?,?,?)",
+                " notifications_enabled, active, include_in_leaderboard, sort_order, id)"
+                " VALUES (?,?,?,?,?,?,?,?,?)",
                 fields + (assignee_id,))
     return get_assignee(database_path, assignee_id)
 

--- a/custom_components/chores_manager/db/overview.py
+++ b/custom_components/chores_manager/db/overview.py
@@ -82,6 +82,53 @@ def overview(database_path: str, today: date) -> dict:
     }
 
 
+_PRIORITY_RANK = {"critical": 0, "high": 1, "normal": 2, "low": 3}
+
+
+def notification_summary(database_path: str, today: date) -> dict:
+    """Per actieve persoon wat er nú speelt, voor de ochtendmelding (§6).
+
+    'anyone'-taken tellen voor iedereen mee; 'fixed' en 'rotating' alleen
+    voor wie aan de beurt is. Alleen vandaag en achterstand — upcoming hoort
+    niet in een ochtendmelding. De lijsten zijn voorgesorteerd op
+    belangrijkheid (achterstand op cyclusfractie, vandaag op prioriteit en
+    dan duur), zodat pick_notify_action gewoon de kop pakt.
+    """
+    chores = [enrich_chore(database_path, chore, today)
+              for chore in list_chores(database_path)]
+    summary = {}
+    for person in list_assignees(database_path):
+        mine = [c for c in chores
+                if c["assignment_type"] == "anyone"
+                or c["current_assignee"] == person["id"]]
+        due = sorted(
+            (c for c in mine if c["urgency"] == "due"),
+            key=lambda c: (_PRIORITY_RANK.get(c["priority"], 9),
+                           c["duration_minutes"]))
+        overdue = sorted(
+            (c for c in mine if c["overdue_days"] > 0),
+            key=lambda c: -(c["cycle_fraction"] or 0))
+        summary[person["id"]] = {
+            "assignee": dict(person), "due": due, "overdue": overdue}
+    return summary
+
+
+def pick_notify_action(due: list, overdue: list):
+    """De taak achter de ene "Klaar"-knop in de ochtendmelding.
+
+    Eerst de zwaarste achterstand (hoogste cyclusfractie — die dreigt bij de
+    volgende rol door te schuiven, dus daar helpt een knop het meest),
+    anders de belangrijkste taak van vandaag (prioriteit, bij gelijke
+    prioriteit de kortste: de laagste drempel om 'm echt in te drukken).
+    De lijsten komen voorgesorteerd uit notification_summary.
+    """
+    if overdue:
+        return overdue[0]
+    if due:
+        return due[0]
+    return None
+
+
 def build_state(database_path: str, today: date, feed_limit: int = 100) -> dict:
     """De volledige begintoestand voor chores_manager/state (§2.3).
 

--- a/custom_components/chores_manager/db/schema.py
+++ b/custom_components/chores_manager/db/schema.py
@@ -21,6 +21,7 @@ CREATE TABLE IF NOT EXISTS assignees (
     color                  TEXT NOT NULL,
     ha_user_id             TEXT,               -- koppeling voor notificaties
     notify_service         TEXT,               -- bv. notify.mobile_app_martijn
+    notifications_enabled  INTEGER NOT NULL DEFAULT 1,  -- aan/uit per persoon (§6)
     active                 INTEGER NOT NULL DEFAULT 1,
     include_in_leaderboard INTEGER NOT NULL DEFAULT 1,
     sort_order             INTEGER NOT NULL DEFAULT 0
@@ -89,6 +90,21 @@ CREATE INDEX IF NOT EXISTS idx_completions_chore
 def apply_schema(conn: sqlite3.Connection) -> None:
     """Leg het v2-schema aan op een open verbinding. Idempotent."""
     conn.executescript(SCHEMA)
+    _migrate(conn)
+
+
+def _migrate(conn: sqlite3.Connection) -> None:
+    """Kleine, idempotente migraties voor databases van vóór een kolom.
+
+    CREATE TABLE IF NOT EXISTS raakt een bestaande tabel niet aan, dus een
+    kolom die later aan het schema is toegevoegd, moet hier per bestaande
+    database met ALTER TABLE bijgezet worden.
+    """
+    kolommen = {row[1] for row in conn.execute("PRAGMA table_info(assignees)")}
+    if "notifications_enabled" not in kolommen:
+        # fase 4: meldingen aan/uit per persoon; standaard aan (§6)
+        conn.execute("ALTER TABLE assignees ADD COLUMN"
+                     " notifications_enabled INTEGER NOT NULL DEFAULT 1")
 
 
 def create_database(database_path: str) -> None:

--- a/custom_components/chores_manager/manifest.json
+++ b/custom_components/chores_manager/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "chores_manager",
   "name": "Chores Manager",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "documentation": "https://github.com/HAChoresManager/Home-Assistant-Chores-Manager",
   "dependencies": ["sensor", "panel_custom", "websocket_api"],
   "codeowners": [],

--- a/custom_components/chores_manager/notify.py
+++ b/custom_components/chores_manager/notify.py
@@ -1,0 +1,253 @@
+"""Meldingen (§6, fase 4): ochtendoverzicht, weeksamenvatting en "Klaar".
+
+Alleen naar personen met een ingevulde notify_service én meldingen aan
+(notifications_enabled); wie niets ingevuld heeft, krijgt niets en houdt de
+log stil. De teksten volgen de toon van het panel: actief, Nederlands, geen
+verwijt — daarom noemt de ochtendmelding wat er vandaag speelt met namen, en
+nooit het kale totaal.
+
+Volgorde-afhankelijkheid: de scheduler rolt om 03:00 de vervaldata door
+(§4.2); de ochtendmelding van 08:00 leest daarna gewoon de actuele staat.
+Het zijn twee losse taken zonder koppeling — maar verzet de meldingstijd
+nooit tot vóór de rol, anders meldt hij de staat van gisteren.
+
+De "Klaar"-knop is het minst gebaande pad. De companion-app toont de knop
+uit data.actions en vuurt bij het tikken een event
+``mobile_app_notification_action`` met daarin onze action-string. Taak en
+ontvanger zitten in die string gecodeerd:
+``chores_manager_complete:<chore_id>:<assignee_id>`` (ids zijn slugs zonder
+dubbele punt). De listener hieronder vangt het event, vinkt af via dezelfde
+db-functie als het panel, vult dezelfde undo-buffer en stuurt hetzelfde
+dispatchersignaal — het panel ziet het dus direct (push) en de minuten staan
+op naam van de ontvanger van de melding.
+"""
+from __future__ import annotations
+
+import logging
+import time
+
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_track_time_change
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    DATA_UNDO,
+    DOMAIN,
+    MORNING_HOUR,
+    MORNING_MINUTE,
+    NOTIFY_ACTION_PREFIX,
+    SIGNAL_UPDATED,
+    WEEKLY_DAY,
+    WEEKLY_HOUR,
+    WEEKLY_MINUTE,
+)
+from .db.assignees import list_assignees
+from .db.completions import assignee_streaks, complete_chore, leaderboard
+from .db.overview import notification_summary, pick_notify_action
+
+_LOGGER = logging.getLogger(__name__)
+
+MOBILE_APP_ACTION_EVENT = "mobile_app_notification_action"
+
+
+def _duur(minutes: int) -> str:
+    """Zelfde vorm als het panel (format.js): "20m", "1u", "1u 20m"."""
+    total = max(0, round(minutes))
+    hours, rest = divmod(total, 60)
+    if hours == 0:
+        return f"{rest}m"
+    if rest == 0:
+        return f"{hours}u"
+    return f"{hours}u {rest}m"
+
+
+def _opsomming(namen: list[str]) -> str:
+    """"A", "A en B", "A, B en C"."""
+    if len(namen) <= 1:
+        return "".join(namen)
+    return f"{', '.join(namen[:-1])} en {namen[-1]}"
+
+
+def _notify_target(notify_service: str) -> str | None:
+    """"notify.mobile_app_x" → "mobile_app_x"; kale servicenaam mag ook."""
+    if not notify_service:
+        return None
+    if notify_service.startswith("notify."):
+        return notify_service.split(".", 1)[1] or None
+    return notify_service
+
+
+def _daily_payload(entry: dict) -> dict | None:
+    """Bouw de ochtendmelding voor één persoon; None als er niets speelt."""
+    due, overdue = entry["due"], entry["overdue"]
+    if not due and not overdue:
+        return None
+
+    kop = []
+    if due:
+        kop.append(f"{len(due)} voor vandaag")
+    if overdue:
+        kop.append("1 loopt achter" if len(overdue) == 1
+                   else f"{len(overdue)} lopen achter")
+    regels = []
+    if due:
+        regels.append(f"Vandaag: {_opsomming([c['name'] for c in due])}.")
+    if overdue:
+        regels.append(f"Achterstand: {_opsomming([c['name'] for c in overdue])}.")
+
+    payload = {
+        "title": ", ".join(kop),
+        "message": " ".join(regels),
+        "data": {
+            # vervangt de melding van gisteren in plaats van te stapelen
+            "tag": "chores_manager_daily",
+        },
+    }
+    actie = pick_notify_action(due, overdue)
+    if actie:
+        payload["data"]["actions"] = [{
+            "action": (f"{NOTIFY_ACTION_PREFIX}:{actie['id']}"
+                       f":{entry['assignee']['id']}"),
+            "title": "Klaar",
+        }]
+    return payload
+
+
+def _weekly_message(board: dict, streaks: dict) -> str:
+    """De eindstand: samen eerst, dan de verdeling. Feiten, geen ranglijsttaal."""
+    if not board["total_minutes"]:
+        return ("Deze week is er niets afgevinkt. "
+                "Maandag begint de teller opnieuw.")
+    regels = [f"Samen {_duur(board['total_minutes'])} dit huishouden "
+              "draaiende gehouden."]
+    for person in board["persons"]:
+        if not person["tasks"]:
+            continue
+        taken = "1 taak" if person["tasks"] == 1 else f"{person['tasks']} taken"
+        regel = f"{person['name']}: {_duur(person['minutes'])} · {taken}"
+        streak = streaks.get(person["id"], 0)
+        if streak >= 2:
+            regel += f" · {streak} weken op rij"
+        regels.append(regel)
+    return "\n".join(regels)
+
+
+async def _send(hass: HomeAssistant, notify_service: str, payload: dict) -> None:
+    target = _notify_target(notify_service)
+    if not target:
+        return
+    await hass.services.async_call("notify", target, payload, blocking=False)
+
+
+def _wil_meldingen(persoon: dict) -> bool:
+    """Alleen wie een service heeft én meldingen aan (§6: per persoon)."""
+    return bool(persoon.get("notify_service")
+                and persoon.get("notifications_enabled", 1))
+
+
+async def async_send_daily(hass: HomeAssistant, database_path: str) -> int:
+    """Ochtendmelding per persoon; alleen als er voor die persoon iets is.
+
+    Geeft het aantal verzonden meldingen terug (handig voor de logregel van
+    de tijdelijke testservice).
+    """
+    today = dt_util.now().date()
+    summary = await hass.async_add_executor_job(
+        notification_summary, database_path, today)
+    verzonden = 0
+    for entry in summary.values():
+        persoon = entry["assignee"]
+        if not _wil_meldingen(persoon):
+            continue
+        payload = _daily_payload(entry)
+        if not payload:
+            continue
+        await _send(hass, persoon["notify_service"], payload)
+        verzonden += 1
+    if verzonden:
+        _LOGGER.info("Chores Manager: ochtendmelding naar %d personen", verzonden)
+    return verzonden
+
+
+async def async_send_weekly(hass: HomeAssistant, database_path: str) -> int:
+    """Weeksamenvatting naar iedereen met een service; de feiten van de week."""
+    today = dt_util.now().date()
+    board = await hass.async_add_executor_job(leaderboard, database_path, today)
+    streaks = await hass.async_add_executor_job(
+        assignee_streaks, database_path, today)
+    assignees = await hass.async_add_executor_job(list_assignees, database_path)
+    message = _weekly_message(board, streaks)
+    verzonden = 0
+    for persoon in filter(_wil_meldingen, assignees):
+        await _send(hass, persoon["notify_service"], {
+            "title": "De week in het huishouden",
+            "message": message,
+            "data": {"tag": "chores_manager_weekly"},
+        })
+        verzonden += 1
+    if verzonden:
+        _LOGGER.info("Chores Manager: weeksamenvatting naar %d personen", verzonden)
+    return verzonden
+
+
+async def _async_complete_from_action(
+    hass: HomeAssistant, database_path: str, chore_id: str, assignee_id: str,
+) -> None:
+    """Afvinken zoals het panel het doet: zelfde db-functie, zelfde
+    undo-buffer, zelfde signaal."""
+    now = dt_util.now()
+    try:
+        undo = await hass.async_add_executor_job(
+            complete_chore, database_path, chore_id, assignee_id,
+            now.date(), now.isoformat(), None, None)
+    except ValueError as err:
+        _LOGGER.warning(
+            "Chores Manager: afvinken via melding mislukt (%s door %s): %s",
+            chore_id, assignee_id, err)
+        return
+    hass.data[DOMAIN][DATA_UNDO] = {"undo": undo, "at": time.monotonic()}
+    async_dispatcher_send(hass, SIGNAL_UPDATED,
+                          {"reason": "complete", "chore_id": chore_id})
+    _LOGGER.info("Chores Manager: %s afgevinkt via melding door %s",
+                 chore_id, assignee_id)
+
+
+@callback
+def async_setup_notifications(hass: HomeAssistant, database_path: str):
+    """Zet de twee tijdstippen en de action-listener op; geeft één
+    opruimfunctie terug."""
+
+    async def _morgen(now) -> None:
+        await async_send_daily(hass, database_path)
+
+    async def _zondagavond(now) -> None:
+        # async_track_time_change kent geen weekdag; zelf filteren.
+        if dt_util.now().weekday() == WEEKLY_DAY:
+            await async_send_weekly(hass, database_path)
+
+    async def _on_action(event: Event) -> None:
+        action = event.data.get("action")
+        if not isinstance(action, str) or not action.startswith(
+                f"{NOTIFY_ACTION_PREFIX}:"):
+            return
+        parts = action.split(":")
+        if len(parts) != 3:
+            _LOGGER.warning("Chores Manager: onleesbare action-string: %s", action)
+            return
+        await _async_complete_from_action(hass, database_path, parts[1], parts[2])
+
+    unsubs = [
+        async_track_time_change(
+            hass, _morgen, hour=MORNING_HOUR, minute=MORNING_MINUTE, second=0),
+        async_track_time_change(
+            hass, _zondagavond, hour=WEEKLY_HOUR, minute=WEEKLY_MINUTE, second=0),
+        hass.bus.async_listen(MOBILE_APP_ACTION_EVENT, _on_action),
+    ]
+
+    @callback
+    def _unsub_all() -> None:
+        for unsub in unsubs:
+            unsub()
+
+    return _unsub_all

--- a/custom_components/chores_manager/panel.py
+++ b/custom_components/chores_manager/panel.py
@@ -28,7 +28,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PANEL_VERSION = "2.2.0-20260728-fase3c"
+PANEL_VERSION = "2.3.0-20260728-fase4"
 FRONTEND_URL_PATH = "taken"
 STATIC_URL = "/chores_manager-panel"
 _DATA_STATIC_REGISTERED = "panel_static_registered"

--- a/custom_components/chores_manager/services.yaml
+++ b/custom_components/chores_manager/services.yaml
@@ -16,3 +16,17 @@ roll_forward:
     achterstand voorbij de grens van hun prioriteit is, schuiven door naar
     hun eerstvolgende logische datum (REFACTOR_PLAN.md §4.2). Normaal
     gesproken is deze service niet nodig.
+
+send_daily_summary:
+  name: Ochtendmelding nu versturen (tijdelijk)
+  description: >-
+    TIJDELIJK, net als seed — verstuurt de ochtendmelding van 08:00 nu
+    meteen, om de meldingen te testen zonder de klok te verzetten. Alleen
+    personen met een ingevulde meldingsservice en iets te doen krijgen er
+    één.
+
+send_weekly_summary:
+  name: Weeksamenvatting nu versturen (tijdelijk)
+  description: >-
+    TIJDELIJK, net als seed — verstuurt de weeksamenvatting van zondag
+    20:00 nu meteen, naar iedereen met een ingevulde meldingsservice.

--- a/custom_components/chores_manager/www/chores-panel/chores-panel.js
+++ b/custom_components/chores_manager/www/chores-panel/chores-panel.js
@@ -70,6 +70,30 @@ function viewFromHash() {
   return VIEWS[hash] ? hash : 'vandaag';
 }
 
+/**
+ * Opties voor het personenformulier (fase 4), vers uit hass op het moment
+ * dat het formulier opent. HA-gebruikers komen uit de person-entiteiten
+ * (attributes.user_id) — dat kan zonder admin-endpoint; de user-lijst van
+ * config/auth/list is admin-only en dus bewust niet gebruikt. Wie geen
+ * person-entiteit heeft, staat er niet tussen; een bestaande koppeling
+ * blijft in het formulier altijd zichtbaar als eigen optie.
+ */
+function haOptionsFromHass(hass) {
+  const users = [];
+  for (const [entityId, entity] of Object.entries(hass?.states || {})) {
+    if (!entityId.startsWith('person.')) continue;
+    const userId = entity.attributes?.user_id;
+    if (!userId) continue;
+    users.push({ id: userId, name: entity.attributes.friendly_name || entityId });
+  }
+  users.sort((a, b) => a.name.localeCompare(b.name));
+  const services = Object.keys(hass?.services?.notify || {})
+    .filter((name) => name.startsWith('mobile_app_'))
+    .sort()
+    .map((name) => `notify.${name}`);
+  return { users, services };
+}
+
 function renderNav(view, narrow) {
   // Smal scherm: HA verbergt de zijbalk, dus zonder eigen knop is er geen
   // enkele weg terug het menu in. hass-toggle-menu is HA's standaardevent
@@ -177,7 +201,8 @@ class ChoresPanel extends HTMLElement {
     this._started = true;
     // Bewaarde themakeuze toepassen vóór de eerste render — geen flits.
     this._syncThemes();
-    store.set({ view: viewFromHash() });
+    // Voor de chip-default op 'anyone'-taken (§4.4, fase 4): wie ben ik?
+    store.set({ view: viewFromHash(), currentUserId: this._hass?.user?.id || null });
     this._unsubStore = store.subscribe(() => this._render());
     this._render();
     await this._refresh();
@@ -305,9 +330,16 @@ class ChoresPanel extends HTMLElement {
     } else if (action === 'edit-chore') {
       store.set({ editing: { kind: 'chore', id: choreId, confirm: false } });
     } else if (action === 'new-assignee') {
-      store.set({ editing: { kind: 'assignee', id: null, confirm: false } });
+      // haOptions vers uit hass, precies op het moment dat het formulier opent
+      store.set({
+        editing: { kind: 'assignee', id: null, confirm: false },
+        haOptions: haOptionsFromHass(this._hass),
+      });
     } else if (action === 'edit-assignee') {
-      store.set({ editing: { kind: 'assignee', id: assigneeId, confirm: false } });
+      store.set({
+        editing: { kind: 'assignee', id: assigneeId, confirm: false },
+        haOptions: haOptionsFromHass(this._hass),
+      });
     } else if (action === 'form-cancel') {
       store.set({ editing: null });
     } else if (action === 'delete-ask') {

--- a/custom_components/chores_manager/www/chores-panel/components/task-card.js
+++ b/custom_components/chores_manager/www/chores-panel/components/task-card.js
@@ -5,7 +5,10 @@
  * Het chipje (§4.4) toont wie de credits krijgt en is tikbaar: standaard de
  * toewijzing, tikken opent de keuze uit alle actieve personen. Zo blijft het
  * gewone geval één tik en is "Laura deed Martijns taak" er twee. Bij 'anyone'
- * is het chipje neutraal ("wie kan") en opent Afvinken zelf de keuze.
+ * staat het chipje sinds fase 4 standaard op de persoon die via ha_user_id
+ * aan de ingelogde HA-gebruiker gekoppeld is (ctx.defaultAssignee); zonder
+ * koppeling blijft het neutraal ("wie kan") en opent Afvinken zelf de keuze.
+ * De keuze blijft altijd aanpasbaar via het chipje.
  *
  * Twee keuzemodi lopen door dezelfde personenrij: mode 'complete' vinkt af
  * bij de keuze (de anyone-flow), mode 'credit' zet alleen het chipje.
@@ -36,14 +39,16 @@ export function isFinalAction(chore, subtaskId) {
   return true;
 }
 
-/** Wie krijgt de credits: het chipje als dat gezet is, anders de toewijzing. */
-export function creditAssignee(chore, credits) {
-  if (credits && credits[chore.id]) return credits[chore.id];
-  return chore.assignment_type === 'anyone' ? null : chore.current_assignee;
+/** Wie krijgt de credits: het chipje als dat gezet is; bij 'anyone' de aan
+ * de ingelogde gebruiker gekoppelde persoon (fase 4); anders de toewijzing. */
+export function creditAssignee(chore, ctx) {
+  if (ctx.credits && ctx.credits[chore.id]) return ctx.credits[chore.id];
+  if (chore.assignment_type === 'anyone') return ctx.defaultAssignee || null;
+  return chore.current_assignee;
 }
 
 function chip(chore, ctx) {
-  const creditId = creditAssignee(chore, ctx.credits);
+  const creditId = creditAssignee(chore, ctx);
   if (!creditId) {
     return html`<button type="button" class="chip neutral" data-action="choose-credit"
       data-chore="${chore.id}" title="Kies wie het doet">wie kan<span class="chip-caret">▾</span></button>`;
@@ -139,7 +144,7 @@ export function renderTaskCard(chore, ctx) {
   const badge = days > 0
     ? html`<span class="badge ${chore.urgency}">${overdueLabel(days, chore.next_due, ctx.todayIso)}</span>`
     : '';
-  const creditId = creditAssignee(chore, ctx.credits);
+  const creditId = creditAssignee(chore, ctx);
   const isChecklist = chore.subtask_mode === 'checklist';
   const cardChooser = ctx.chooser
     && ctx.chooser.choreId === chore.id && ctx.chooser.subtaskId === undefined;

--- a/custom_components/chores_manager/www/chores-panel/core/store.js
+++ b/custom_components/chores_manager/www/chores-panel/core/store.js
@@ -22,6 +22,10 @@
  *   narrow    HA verbergt de zijbalk (smal scherm) → hamburger tonen
  *   themes    {names, selected} voor de themakeuze in Beheer, of null
  *             zolang hass.themes nog niet gezien is
+ *   currentUserId  hass.user.id van de kijker; voor de chip-default op
+ *                  'anyone'-taken via de ha_user_id-koppeling (fase 4)
+ *   haOptions {users, services} voor het personenformulier, vers gezet
+ *             bij het openen ervan; null tot die tijd
  */
 
 let state = {
@@ -36,6 +40,8 @@ let state = {
   editing: null,
   narrow: false,
   themes: null,
+  currentUserId: null,
+  haOptions: null,
 };
 
 const listeners = new Set();

--- a/custom_components/chores_manager/www/chores-panel/views/manage.js
+++ b/custom_components/chores_manager/www/chores-panel/views/manage.js
@@ -81,8 +81,14 @@ function deleteBlock(kind, subject, confirm) {
     </div>`;
 }
 
-function assigneeForm(person, confirm) {
+function assigneeForm(person, confirm, haOptions) {
   const isNew = !person;
+  const users = haOptions?.users || [];
+  const services = haOptions?.services || [];
+  const linkedUser = person?.ha_user_id || '';
+  const userKnown = users.some((u) => u.id === linkedUser);
+  const service = person?.notify_service || '';
+  const serviceKnown = services.includes(service);
   return html`
     <form data-form="assignee" class="manage-form" novalidate>
       <h2 class="section-title">${isNew ? 'Nieuwe persoon' : html`Bewerken: ${person.name}`}</h2>
@@ -98,6 +104,34 @@ function assigneeForm(person, confirm) {
           ${!person || person.include_in_leaderboard ? 'checked' : ''}>
         Telt mee in de ranglijst
       </label>
+
+      <h2 class="section-title">Koppeling en meldingen</h2>
+      <label class="field">Home Assistant-gebruiker
+        <select name="ha_user_id">
+          <option value="">Niet gekoppeld</option>
+          ${linkedUser && !userKnown
+            ? html`<option value="${linkedUser}" selected>${linkedUser} (huidige koppeling)</option>` : ''}
+          ${users.map((u) => html`
+            <option value="${u.id}" ${u.id === linkedUser ? 'selected' : ''}>${u.name}</option>`)}
+        </select>
+      </label>
+      <label class="field">Meldingen naar
+        <select name="notify_service">
+          <option value="">Geen meldingen</option>
+          ${services.map((name) => html`
+            <option value="${name}" ${name === service ? 'selected' : ''}>${name}</option>`)}
+        </select>
+      </label>
+      <label class="field">Andere service (als hij hierboven niet staat)
+        <input type="text" name="notify_service_custom" placeholder="notify.…"
+          value="${service && !serviceKnown ? service : ''}">
+      </label>
+      <label class="check standalone">
+        <input type="checkbox" name="notifications_enabled"
+          ${!person || person.notifications_enabled ? 'checked' : ''}>
+        Meldingen aan
+      </label>
+
       <p class="form-error" data-form-error hidden></p>
       <div class="form-actions">
         <button type="submit" class="primary">Opslaan</button>
@@ -122,7 +156,7 @@ export function renderManage(state) {
   if (editing && editing.kind === 'assignee') {
     const person = editing.id ? data.assignees.find((a) => a.id === editing.id) : null;
     if (editing.id && !person) return html`<p class="status">Persoon niet gevonden.</p>`;
-    return assigneeForm(person, editing.confirm);
+    return assigneeForm(person, editing.confirm, state.haOptions);
   }
 
   return html`
@@ -149,10 +183,20 @@ export function collectAssigneeForm(form) {
   if (!name) throw new Error('Geef de persoon een naam.');
   const id = String(data.get('id') || '') || slugify(name);
   if (!id) throw new Error('De naam moet minstens één letter of cijfer bevatten.');
+  // het vrije veld wint van de select: dat is de fallback voor services
+  // die niet in de mobile_app-lijst staan
+  const custom = String(data.get('notify_service_custom') || '').trim();
+  if (custom && !custom.startsWith('notify.')) {
+    throw new Error('Een meldingsservice begint met "notify." — bv. notify.mobile_app_telefoon.');
+  }
+  const notifyService = custom || String(data.get('notify_service') || '');
   return {
     id,
     name,
     color: String(data.get('color') || '#7cb342'),
     include_in_leaderboard: data.get('include_in_leaderboard') ? 1 : 0,
+    ha_user_id: String(data.get('ha_user_id') || '') || null,
+    notify_service: notifyService || null,
+    notifications_enabled: data.get('notifications_enabled') ? 1 : 0,
   };
 }

--- a/custom_components/chores_manager/www/chores-panel/views/tasks.js
+++ b/custom_components/chores_manager/www/chores-panel/views/tasks.js
@@ -32,11 +32,15 @@ export function renderTasks(state) {
   const data = state.data;
   const assigneesById = {};
   for (const person of data.assignees) assigneesById[person.id] = person;
+  // A2 (fase 4): de kijker, voor de chip-default op 'anyone'-taken.
+  const me = data.assignees.find(
+    (p) => p.ha_user_id && p.ha_user_id === state.currentUserId);
   const ctx = {
     assigneesById,
     assignees: data.assignees,
     chooser: state.chooser,
     credits: state.credits,
+    defaultAssignee: me ? me.id : null,
     expanded: state.expanded,
     todayIso: data.today,
     view: 'tasks',

--- a/custom_components/chores_manager/www/chores-panel/views/today.js
+++ b/custom_components/chores_manager/www/chores-panel/views/today.js
@@ -55,11 +55,15 @@ export function renderToday(state) {
   const data = state.data;
   const assigneesById = {};
   for (const person of data.assignees) assigneesById[person.id] = person;
+  // A2 (fase 4): de kijker, voor de chip-default op 'anyone'-taken.
+  const me = data.assignees.find(
+    (p) => p.ha_user_id && p.ha_user_id === state.currentUserId);
   const ctx = {
     assigneesById,
     assignees: data.assignees,
     chooser: state.chooser,
     credits: state.credits,
+    defaultAssignee: me ? me.id : null,
     expanded: state.expanded,
     todayIso: data.today,
     view: 'today',

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -44,7 +44,9 @@ node de ES-module).
   De versie zit in het statische pad; zie `CLAUDE.md` § Deployment voor het
   waarom en de valkuilen (Cloudflare!).
 - Services voor de hand: `chores_manager.seed` (tijdelijk, vult de acht
-  legacy-taken) en `chores_manager.roll_forward` (nachtelijke rol nu draaien).
+  legacy-taken), `chores_manager.roll_forward` (nachtelijke rol nu draaien)
+  en — tijdelijk, om meldingen te testen — `send_daily_summary` en
+  `send_weekly_summary`.
 
 ## Kaartgebruik (optioneel)
 

--- a/docs/technical-description.md
+++ b/docs/technical-description.md
@@ -1,6 +1,6 @@
 # Technical Description — Chores Manager 2.x
 
-Stand: 28-07-2026, na fase 3c. De oude app (1.x) is volledig verwijderd; dit
+Stand: 28-07-2026, na fase 4. De oude app (1.x) is volledig verwijderd; dit
 document beschrijft alleen wat er draait. Ontwerpmotivatie: `REFACTOR_PLAN.md`.
 
 ## Database
@@ -61,6 +61,22 @@ Dagelijks 03:00 lokale tijd: `roll_forward` over alle taken, daarna een
 dispatchersignaal. Handmatig triggeren kan met de service
 `chores_manager.roll_forward`.
 
+## Meldingen (`notify.py`, fase 4)
+
+Alleen naar personen met een `notify_service` én `notifications_enabled`.
+
+- **08:00** per persoon, alleen als er iets te doen is: "3 voor vandaag,
+  1 loopt achter" met taaknamen, plus één "Klaar"-knop voor de belangrijkste
+  taak (zwaarste achterstand op cyclusfractie; anders hoogste prioriteit,
+  dan kortste). De rol van 03:00 draait hier bewust vóór.
+- **Zondag 20:00** de weeksamenvatting: samen eerst, dan de verdeling met
+  tijd, taken en reeksen. Feiten, geen ranglijsttaal.
+- **"Klaar"** loopt via `mobile_app_notification_action`; de action-string is
+  `chores_manager_complete:<chore_id>:<assignee_id>`. De listener vinkt af
+  met dezelfde db-functie, undo-buffer en push als het panel.
+
+Tijden staan als constanten in `const.py` (fase 5 kan ze instelbaar maken).
+
 ## Frontend (`www/chores-panel/`)
 
 Eén web component `<chores-panel>` (shadow DOM), als panel op `/taken` en als
@@ -87,5 +103,7 @@ Lovelace-resource-URL.
 
 - `chores_manager.seed` — TIJDELIJK; acht legacy-taken en drie personen.
 - `chores_manager.roll_forward` — de nachtelijke rol nu.
+- `chores_manager.send_daily_summary` — TIJDELIJK; de ochtendmelding nu.
+- `chores_manager.send_weekly_summary` — TIJDELIJK; de weeksamenvatting nu.
 
 Meer services zijn er niet; alle bediening loopt via de WebSocket-API.

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,142 @@
+"""Fase 4: de meldingsdata (notification_summary, pick_notify_action), de
+nieuwe notifications_enabled-kolom en de schemamigratie voor databases van
+vóór die kolom. De meldingsteksten zelf leven in notify.py (HA-laag) en
+vallen buiten pytest — dit dekt alles waarop die teksten bouwen.
+"""
+from datetime import date, timedelta
+import sqlite3
+
+import pytest
+
+from chores_manager.db.assignees import get_assignee, save_assignee
+from chores_manager.db.chores import save_chore
+from chores_manager.db.overview import notification_summary, pick_notify_action
+from chores_manager.db.schema import create_database
+
+VANDAAG = date(2026, 7, 28)
+NU = "2026-07-28T10:00:00+02:00"
+
+
+@pytest.fixture
+def db(tmp_path):
+    pad = str(tmp_path / "chores_v2.db")
+    create_database(pad)
+    save_assignee(pad, {"id": "laura", "name": "Laura", "color": "#83c44a",
+                        "notify_service": "notify.mobile_app_laura"})
+    save_assignee(pad, {"id": "martijn", "name": "Martijn", "color": "#4dd8ff"})
+    return pad
+
+
+def _taak(db, **extra):
+    data = {
+        "id": "was", "name": "Was draaien", "schedule_type": "daily",
+        "schedule_config": {"weekdays": [1, 2, 3, 4, 5, 6, 7]},
+        "duration_minutes": 20, "assignment_type": "fixed", "assigned_to": "laura",
+    }
+    data.update(extra)
+    return save_chore(db, data, VANDAAG, NU)
+
+
+class TestNotificationSummary:
+    def test_fixed_telt_alleen_bij_de_eigenaar(self, db):
+        _taak(db)  # fixed, laura, vandaag
+        summary = notification_summary(db, VANDAAG)
+        assert [c["id"] for c in summary["laura"]["due"]] == ["was"]
+        assert summary["martijn"]["due"] == []
+        assert summary["martijn"]["overdue"] == []
+
+    def test_anyone_telt_voor_iedereen(self, db):
+        _taak(db, id="afwas", name="Afwassen",
+              assignment_type="anyone", assigned_to=None)
+        summary = notification_summary(db, VANDAAG)
+        assert [c["id"] for c in summary["laura"]["due"]] == ["afwas"]
+        assert [c["id"] for c in summary["martijn"]["due"]] == ["afwas"]
+
+    def test_rotating_telt_alleen_bij_wie_aan_de_beurt_is(self, db):
+        _taak(db, id="vuilnis", name="Vuilnis", assignment_type="rotating",
+              assigned_to=None, rotation=["martijn", "laura"])
+        summary = notification_summary(db, VANDAAG)
+        assert [c["id"] for c in summary["martijn"]["due"]] == ["vuilnis"]
+        assert summary["laura"]["due"] == []
+
+    def test_upcoming_hoort_niet_in_de_ochtendmelding(self, db):
+        _taak(db, next_due=VANDAAG + timedelta(days=1))
+        summary = notification_summary(db, VANDAAG)
+        assert summary["laura"]["due"] == []
+        assert summary["laura"]["overdue"] == []
+
+    def test_achterstand_gesorteerd_op_cyclusfractie(self, db):
+        # dagtaak 3 dagen te laat (fractie 3,0) staat vóór een 30-dagentaak
+        # die 5 dagen te laat is (fractie 0,17) — absolute dagen zouden
+        # verkeerd sorteren (§4.3).
+        _taak(db, id="dagelijks", name="Dagelijks",
+              next_due=VANDAAG - timedelta(days=3))
+        _taak(db, id="maandelijks", name="Maandelijks",
+              schedule_type="interval", schedule_config={"days": 30},
+              next_due=VANDAAG - timedelta(days=5))
+        summary = notification_summary(db, VANDAAG)
+        assert [c["id"] for c in summary["laura"]["overdue"]] == [
+            "dagelijks", "maandelijks"]
+
+    def test_vandaag_gesorteerd_op_prioriteit_dan_duur(self, db):
+        _taak(db, id="lang", name="Lang", priority="normal", duration_minutes=45)
+        _taak(db, id="belangrijk", name="Belangrijk", priority="high",
+              duration_minutes=60)
+        _taak(db, id="kort", name="Kort", priority="normal", duration_minutes=5)
+        summary = notification_summary(db, VANDAAG)
+        assert [c["id"] for c in summary["laura"]["due"]] == [
+            "belangrijk", "kort", "lang"]
+
+
+class TestPickNotifyAction:
+    def test_achterstand_wint_van_vandaag(self, db):
+        _taak(db, id="vandaag-taak", name="Vandaag")
+        _taak(db, id="te-laat", name="Te laat",
+              next_due=VANDAAG - timedelta(days=2))
+        entry = notification_summary(db, VANDAAG)["laura"]
+        assert pick_notify_action(entry["due"], entry["overdue"])["id"] == "te-laat"
+
+    def test_zonder_achterstand_de_belangrijkste_van_vandaag(self, db):
+        _taak(db, id="a", name="A", priority="normal", duration_minutes=30)
+        _taak(db, id="b", name="B", priority="high", duration_minutes=30)
+        entry = notification_summary(db, VANDAAG)["laura"]
+        assert pick_notify_action(entry["due"], entry["overdue"])["id"] == "b"
+
+    def test_niets_te_doen_geeft_none(self, db):
+        assert pick_notify_action([], []) is None
+
+
+class TestNotificationsEnabled:
+    def test_standaard_aan_en_koppelvelden_bewaard(self, db):
+        persoon = get_assignee(db, "laura")
+        assert persoon["notifications_enabled"] == 1
+        assert persoon["notify_service"] == "notify.mobile_app_laura"
+
+        save_assignee(db, {"id": "laura", "name": "Laura", "color": "#83c44a",
+                           "ha_user_id": "abc123",
+                           "notify_service": "notify.mobile_app_laura",
+                           "notifications_enabled": 0})
+        persoon = get_assignee(db, "laura")
+        assert persoon["notifications_enabled"] == 0
+        assert persoon["ha_user_id"] == "abc123"
+
+    def test_migratie_zet_de_kolom_bij_op_een_oude_database(self, tmp_path):
+        # Een database van vóór fase 4: assignees zonder notifications_enabled.
+        pad = str(tmp_path / "oud.db")
+        conn = sqlite3.connect(pad)
+        conn.execute("""
+            CREATE TABLE assignees (
+                id TEXT PRIMARY KEY, name TEXT NOT NULL, color TEXT NOT NULL,
+                ha_user_id TEXT, notify_service TEXT,
+                active INTEGER NOT NULL DEFAULT 1,
+                include_in_leaderboard INTEGER NOT NULL DEFAULT 1,
+                sort_order INTEGER NOT NULL DEFAULT 0)""")
+        conn.execute("INSERT INTO assignees (id, name, color)"
+                     " VALUES ('laura', 'Laura', '#83c44a')")
+        conn.commit()
+        conn.close()
+
+        create_database(pad)  # legt schema aan én draait de migratie
+
+        persoon = get_assignee(pad, "laura")
+        assert persoon["notifications_enabled"] == 1


### PR DESCRIPTION
STAP A — personen koppelen:
- Personenformulier (Beheer) met "Home Assistant-gebruiker" (select uit de person-entiteiten — géén admin-endpoint nodig; een bestaande koppeling buiten die lijst blijft als eigen optie zichtbaar), "Meldingen naar" (select van notify.mobile_app_*-services plus een vrij veld als fallback) en "Meldingen aan". Opslag via assignee/save in ha_user_id, notify_service en het nieuwe notifications_enabled.
- Chip-default op de ingelogde gebruiker: bij 'anyone'-taken staat het persoonschipje standaard op de via ha_user_id gekoppelde persoon; zonder koppeling blijft het "wie kan". Altijd aanpasbaar.

STAP B — meldingen (notify.py):
- Ochtendmelding 08:00, per persoon en alleen als er iets is: "3 voor vandaag, 1 loopt achter" met taaknamen. Eén "Klaar"-knop voor de belangrijkste taak: zwaarste achterstand op cyclusfractie (die dreigt door te rollen), anders hoogste prioriteit en dan de kortste.
- Weeksamenvatting zondag 20:00: samen eerst, dan per persoon tijd, taken en reeksen. Feiten, geen ranglijsttaal.
- "Klaar" via mobile_app_notification_action; action-string chores_manager_complete:<chore_id>:<assignee_id>. De listener vinkt af met dezelfde db-functie, undo-buffer en dispatcher-push als het panel; minuten op naam van de ontvanger.
- Tijden als constanten in const.py (fase 5: instelbaar); volgorde 03:00-rol vóór 08:00-melding gedocumenteerd.
- notifications_enabled-kolom met idempotente migratie in db/schema.py voor bestaande databases.
- Testservices send_daily_summary / send_weekly_summary (TIJDELIJK, net als seed) + services.yaml.

Versie 2.3.0-20260728-fase4 (pad-bump, frontend gewijzigd); manifest 2.3.0. pytest: 193 groen (11 nieuwe meldingstests); node --check groen.


Claude-Session: https://claude.ai/code/session_01JYXAm5rwQW1aLnAaNtL1Zh