### PR TITLE
fix(panel): herstel na HA-herstart — retry op unknown_command (2.3.1)

### DIFF
--- a/custom_components/chores_manager/manifest.json
+++ b/custom_components/chores_manager/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "chores_manager",
   "name": "Chores Manager",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "documentation": "https://github.com/HAChoresManager/Home-Assistant-Chores-Manager",
   "dependencies": ["sensor", "panel_custom", "websocket_api"],
   "codeowners": [],

--- a/custom_components/chores_manager/panel.py
+++ b/custom_components/chores_manager/panel.py
@@ -28,7 +28,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PANEL_VERSION = "2.3.0-20260728-fase4"
+PANEL_VERSION = "2.3.1-20260728-fase4"
 FRONTEND_URL_PATH = "taken"
 STATIC_URL = "/chores_manager-panel"
 _DATA_STATIC_REGISTERED = "panel_static_registered"

--- a/custom_components/chores_manager/www/chores-panel/chores-panel.js
+++ b/custom_components/chores_manager/www/chores-panel/chores-panel.js
@@ -207,7 +207,12 @@ class ChoresPanel extends HTMLElement {
     this._render();
     await this._refresh();
     try {
-      await api.subscribe(() => this._refresh());
+      // subscribe herstelt zichzelf bij een backend die nog niet klaar is
+      // (HA-herstart) en na elke reconnect — zie core/api.js. Moest er
+      // gewacht worden, dan is de eerder opgehaalde staat mogelijk oud.
+      const gewacht = await api.subscribe(
+        () => this._refresh(), () => this._showConnecting());
+      if (gewacht) await this._refresh();
     } catch (err) {
       // zonder abonnement werkt alles nog, alleen zonder live updates
       console.warn('chores-panel: abonneren mislukt', err);
@@ -216,11 +221,21 @@ class ChoresPanel extends HTMLElement {
 
   async _refresh() {
     try {
-      const data = await api.state();
-      store.set({ loading: false, error: null, data, pending: new Set() });
+      const data = await api.state(() => this._showConnecting());
+      store.set({
+        loading: false, connecting: false, error: null, data, pending: new Set(),
+      });
     } catch (err) {
-      store.set({ loading: false, error: err?.message || String(err) });
+      store.set({
+        loading: false, connecting: false, error: err?.message || String(err),
+      });
     }
+  }
+
+  /** De backend is er nog niet (HA-herstart): rustig melden, geen foutscherm.
+   * De retry in core/api.js lost het vanzelf op; _refresh wist de vlag. */
+  _showConnecting() {
+    if (!store.get().connecting) store.set({ connecting: true });
   }
 
   _render() {
@@ -232,7 +247,12 @@ class ChoresPanel extends HTMLElement {
     const body = state.loading || state.error || !state.data
       ? VIEWS.vandaag(state)
       : VIEWS[state.view](state);
-    setContent(this._app, html`${renderNav(state.view, state.narrow)}${body}`);
+    // Rustige melding tijdens het wachten op een herstartende backend; de
+    // bestaande inhoud blijft gewoon staan (geen foutscherm, herstelt zelf).
+    const verbinden = state.connecting && state.data
+      ? html`<p class="reconnect" role="status">Verbinden…</p>` : '';
+    setContent(this._app,
+      html`${renderNav(state.view, state.narrow)}${verbinden}${body}`);
   }
 
   /**
@@ -505,7 +525,15 @@ class ChoresPanel extends HTMLElement {
 }
 
 // Guard: het bestand is op twee URL's bereikbaar (panel geversioneerd,
-// kaartresource ongeversioneerd); een tweede define zou anders gooien.
+// kaartresource ongeversioneerd) en er kunnen oudere module-instanties
+// naast leven (bv. een achtergebleven resource-registratie met een oude
+// URL). De get-check vangt het normale geval; de try/catch vangt wat er
+// dan nog doorheen komt — een tweede define is onschuldig, de eerste
+// registratie blijft gewoon werken.
 if (!customElements.get('chores-panel')) {
-  customElements.define('chores-panel', ChoresPanel);
+  try {
+    customElements.define('chores-panel', ChoresPanel);
+  } catch (err) {
+    console.debug('chores-panel: define overgeslagen, element bestond al', err);
+  }
 }

--- a/custom_components/chores_manager/www/chores-panel/core/api.js
+++ b/custom_components/chores_manager/www/chores-panel/core/api.js
@@ -3,15 +3,39 @@
  *
  * Geen fetch, geen tokens, geen headers: alles loopt over de WebSocket die HA
  * zelf al open heeft. subscribeMessage van home-assistant-js-websocket
- * herabonneert zichzelf na een verbroken verbinding, dus een reconnect
- * herstelt de event-stroom vanzelf; unsubscribe() ruimt netjes op wanneer het
- * panel uit de DOM gaat.
+ * herabonneert zichzelf na een verbroken verbinding; unsubscribe() ruimt
+ * netjes op wanneer het panel uit de DOM gaat.
+ *
+ * HERSTEL NA EEN HA-HERSTART: een herverbindend tabblad kan sneller zijn dan
+ * de integratie — de WebSocket accepteert al verbindingen terwijl de
+ * WS-commando's nog geregistreerd worden. Dan komt er "unknown_command"
+ * terug op state/subscribe, en het interne herabonneren van de bibliotheek
+ * probeert dat nooit opnieuw: het abonnement sterft stil en het panel
+ * bevriest tot een refresh. Daarom hieronder:
+ * - state() en subscribe() proberen bij unknown_command opnieuw met backoff
+ *   (1s, 2s, 5s, daarna elke 10s) tot de backend er is. Dit is geen
+ *   verstopte race (CLAUDE.md) maar herstel van een volgorde die de client
+ *   niet kan afdwingen;
+ * - op het 'ready'-event van de verbinding (elke reconnect) vervangen we
+ *   het abonnement door een vers exemplaar — mét dezelfde retry — en geeft
+ *   de callback één event {reason: 'reconnect'} zodat het panel de
+ *   volledige staat ophaalt en niets gemist blijft.
  */
+
+const RETRY_DELAYS = [1000, 2000, 5000];
+const RETRY_INTERVAL = 10000;
+
+function isUnknownCommand(err) {
+  return err && err.code === 'unknown_command';
+}
 
 class ChoresApi {
   constructor() {
     this._connection = null;
     this._unsubscribe = null;
+    this._callback = null;
+    this._onWaiting = null;
+    this._readyHandler = null;
   }
 
   setHass(hass) {
@@ -25,9 +49,37 @@ class ChoresApi {
     return this._connection.sendMessagePromise(message);
   }
 
-  /** Volledige begintoestand: taken, personen, ranglijst, feed. */
-  state() {
-    return this._send({ type: 'chores_manager/state' });
+  /**
+   * Voer een aanroep uit; bij unknown_command wachten en opnieuw, tot de
+   * backend zijn commando's geregistreerd heeft. Elke andere fout gaat
+   * gewoon omhoog. Geeft {value, retried} terug.
+   */
+  async _withRetry(fn, onWaiting) {
+    let attempt = 0;
+    for (;;) {
+      try {
+        const value = await fn();
+        return { value, retried: attempt > 0 };
+      } catch (err) {
+        if (!isUnknownCommand(err)) throw err;
+        if (onWaiting) onWaiting();
+        const delay = attempt < RETRY_DELAYS.length
+          ? RETRY_DELAYS[attempt] : RETRY_INTERVAL;
+        attempt += 1;
+        await new Promise((resolve) => { setTimeout(resolve, delay); });
+      }
+    }
+  }
+
+  /**
+   * Volledige begintoestand: taken, personen, ranglijst, feed.
+   * onWaiting (optioneel) wordt aangeroepen zodra er gewacht moet worden op
+   * een backend die nog niet klaar is — voor de "Verbinden…"-melding.
+   */
+  async state(onWaiting) {
+    const { value } = await this._withRetry(
+      () => this._send({ type: 'chores_manager/state' }), onWaiting);
+    return value;
   }
 
   /** Taak, deeltaak of counter-tik afvinken. */
@@ -72,14 +124,56 @@ class ChoresApi {
     });
   }
 
-  /** Abonneren op wijzigingen; callback krijgt {reason, ...} per mutatie. */
-  async subscribe(callback) {
-    await this.unsubscribe();
-    this._unsubscribe = await this._connection.subscribeMessage(
-      callback, { type: 'chores_manager/subscribe' });
+  /**
+   * Abonneren op wijzigingen; callback krijgt {reason, ...} per mutatie en
+   * {reason: 'reconnect'} na elk herstel van de verbinding. Geeft terug of
+   * er gewacht moest worden — dan is een extra state-refresh nodig, want in
+   * de wachttijd kan er van alles gebeurd zijn.
+   */
+  async subscribe(callback, onWaiting) {
+    this._callback = callback;
+    this._onWaiting = onWaiting || null;
+    if (!this._readyHandler) {
+      this._readyHandler = () => { this._onConnectionReady(); };
+      this._connection.addEventListener('ready', this._readyHandler);
+    }
+    return this._resubscribe();
   }
 
-  async unsubscribe() {
+  async _resubscribe() {
+    await this._dropSubscription();
+    const { value, retried } = await this._withRetry(
+      () => this._connection.subscribeMessage(
+        (event) => { if (this._callback) this._callback(event); },
+        { type: 'chores_manager/subscribe' }),
+      this._onWaiting);
+    if (!this._callback) {
+      // panel is tijdens het wachten uit de DOM gegaan: meteen weer opzeggen
+      value().catch(() => {});
+      return retried;
+    }
+    this._unsubscribe = value;
+    return retried;
+  }
+
+  /**
+   * Elke reconnect: het interne herabonneren van de bibliotheek kan op een
+   * nog niet klare backend stukgelopen zijn; vervang het abonnement daarom
+   * altijd door een vers exemplaar en laat het panel de staat verversen.
+   */
+  async _onConnectionReady() {
+    if (!this._callback) return;
+    try {
+      await this._resubscribe();
+      if (this._callback) this._callback({ reason: 'reconnect' });
+    } catch (err) {
+      console.warn('chores-panel: herabonneren na reconnect mislukt', err);
+    }
+  }
+
+  /** Alleen het lopende abonnement opzeggen; de callback blijft staan
+   * zodat _resubscribe een vers abonnement kan leggen. */
+  async _dropSubscription() {
     if (this._unsubscribe) {
       const unsubscribe = this._unsubscribe;
       this._unsubscribe = null;
@@ -89,6 +183,13 @@ class ChoresApi {
         // verbinding al weg; niets op te ruimen
       }
     }
+  }
+
+  /** Volledig opruimen (panel uit de DOM): abonnement én callback weg, zodat
+   * de ready-handler en een eventueel nog wachtende retry niets meer doen. */
+  async unsubscribe() {
+    this._callback = null;
+    await this._dropSubscription();
   }
 }
 

--- a/custom_components/chores_manager/www/chores-panel/core/store.js
+++ b/custom_components/chores_manager/www/chores-panel/core/store.js
@@ -7,6 +7,9 @@
  *
  * Vorm van de toestand:
  *   loading   eerste keer laden bezig
+ *   connecting  wachten op een backend die nog niet klaar is (HA-herstart);
+ *               rustige "Verbinden…"-melding, geen foutscherm — de retry in
+ *               core/api.js herstelt dit vanzelf
  *   error     foutmelding (string) of null
  *   data      het volledige antwoord van chores_manager/state, of null
  *   pending   Set van chore-ids die optimistisch als afgevinkt gelden
@@ -30,6 +33,7 @@
 
 let state = {
   loading: true,
+  connecting: false,
   error: null,
   data: null,
   pending: new Set(),

--- a/custom_components/chores_manager/www/chores-panel/styles.css
+++ b/custom_components/chores_manager/www/chores-panel/styles.css
@@ -91,6 +91,14 @@ button:focus-visible,
   outline-offset: -2px;
 }
 
+/* Rustige melding boven de inhoud tijdens het wachten op de backend. */
+.reconnect {
+  margin: 0 0 8px;
+  text-align: center;
+  color: var(--secondary-text-color);
+  font-size: 0.85rem;
+}
+
 /* --- kop ------------------------------------------------------------- */
 
 .page-header {

--- a/custom_components/chores_manager/www/chores-panel/views/today.js
+++ b/custom_components/chores_manager/www/chores-panel/views/today.js
@@ -42,7 +42,7 @@ function renderSection(title, chores, ctx) {
 
 export function renderToday(state) {
   if (state.loading) {
-    return html`<div class="status">Taken laden…</div>`;
+    return html`<div class="status">${state.connecting ? 'Verbinden…' : 'Taken laden…'}</div>`;
   }
   if (state.error) {
     return html`


### PR DESCRIPTION
Een herverbindend tabblad kan sneller zijn dan de integratie: de WebSocket accepteert al verbindingen terwijl de WS-commando's nog geregistreerd worden (log: unknown_command om 21:51:51, registratie om 21:52:01). Het interne herabonneren van home-assistant-js-websocket probeert dat nooit opnieuw, dus het abonnement stierf stil en het panel bevroor tot een handmatige refresh.

- core/api.js: state() en subscribe() proberen bij unknown_command opnieuw met backoff (1s, 2s, 5s, daarna elke 10s) tot de backend er is. Op het 'ready'-event van de verbinding (elke reconnect) wordt het abonnement vervangen door een vers exemplaar — mét dezelfde retry — en krijgt het panel {reason: 'reconnect'}, waarna het de volledige staat ophaalt. Moest de eerste subscribe wachten, dan volgt ook een extra refresh. Dit is geen verstopte race maar herstel van een volgorde die de client niet kan afdwingen.
- Tijdens het wachten een rustige "Verbinden…" (connecting-vlag in de store): als statustekst zolang er geen data is, als dun regeltje boven de bestaande inhoud als die er wel is. Geen foutscherm; het wist zichzelf bij de eerste geslaagde refresh.
- Define-guard waterdicht: customElements.get-check direct vóór de define plus try/catch met console.debug, zodat panel, kaartresource en eventuele oudere module-instanties naast elkaar kunnen bestaan.

Versie 2.3.1-20260728-fase4; manifest 2.3.1. pytest 193 groen, node --check groen.


Claude-Session: https://claude.ai/code/session_01JYXAm5rwQW1aLnAaNtL1Zh